### PR TITLE
Upgrade SQLAlchemy to version 2.0.29

### DIFF
--- a/apiserver/requirements.txt
+++ b/apiserver/requirements.txt
@@ -1,7 +1,7 @@
 Flask==3.0.2
 voluptuous==0.12.2
 stringcase==1.2.0
-SQLAlchemy==1.4.32
+SQLAlchemy==2.0.29
 pytz==2022.1
 PyGithub==1.55
 pycryptodome==3.14.1


### PR DESCRIPTION
Upgrades SQLAlchemy to version 2.0.29 as with Flask-SQLAlchemy 3.1.0 minimum version of SQLAlchemy has been bumped to 2.0.16 
https://flask-sqlalchemy.palletsprojects.com/en/3.1.x/changes/#version-3-1-0