### PR TITLE
Add onboarding API endpoint and define OnboardingSteps enum

### DIFF
--- a/web-server/pages/api/resources/orgs/[org_id]/onboarding.ts
+++ b/web-server/pages/api/resources/orgs/[org_id]/onboarding.ts
@@ -1,0 +1,53 @@
+import * as yup from 'yup';
+
+import { Endpoint, nullSchema } from '@/api-helpers/global';
+import { Columns, Table } from '@/constants/db';
+import { OnboardingSteps } from '@/types/resources';
+import { db } from '@/utils/db';
+
+const putSchema = yup.object().shape({
+  onboarding_state: yup
+    .array()
+    .of(yup.string().oneOf(Object.values(OnboardingSteps)).required())
+    .required()
+});
+
+const pathSchema = yup.object().shape({
+  org_id: yup.string().uuid().required()
+});
+
+const endpoint = new Endpoint(pathSchema);
+
+endpoint.handle.GET(nullSchema, async (req, res) => {
+  const { org_id } = req.payload;
+  const results = await db(Table.UIPreferences)
+    .select(Columns[Table.UIPreferences].data)
+    .where(Columns[Table.UIPreferences].entity_id, org_id);
+  return res.send(results[0]?.data ?? { onboarding_state: [] });
+});
+
+endpoint.handle.PUT(putSchema, async (req, res) => {
+  const { org_id, onboarding_state } = req.payload;
+
+  const results = await db(Table.UIPreferences)
+    .insert({
+      entity_type: 'ORG',
+      entity_id: org_id,
+      setting_type: 'ONBOARDING_STATE',
+      data: {
+        onboarding_state
+      },
+      setter_type: 'ORG'
+    })
+    .onConflict([
+      Columns[Table.UIPreferences].setting_type,
+      Columns[Table.UIPreferences].entity_type,
+      Columns[Table.UIPreferences].entity_id
+    ])
+    .merge()
+    .returning('*');
+
+  return res.send(results[0]?.data ?? { onboarding_state: [] });
+});
+
+export default endpoint.serve();

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -994,3 +994,9 @@ export interface UserStat {
   MERGED: number;
   REVIEWED: number;
 }
+
+export enum OnboardingSteps {
+  'WELCOME_SCREEN' = 'WELCOME_SCREEN',
+  'CODE_PROVIDER_INTEGRATED' = 'CODE_PROVIDER_INTEGRATED',
+  'TEAM_CREATED' = 'TEAM_CREATED'
+}


### PR DESCRIPTION
This pull request adds an API endpoint for onboarding and defines the OnboardingSteps enum. The API endpoint handles GET and PUT requests for retrieving and updating the onboarding state of an organization. The OnboardingSteps enum defines the possible steps in the onboarding process, including WELCOME_SCREEN, CODE_PROVIDER_INTEGRATED, and TEAM_CREATED.