### PR TITLE
Add getMissingPATScopes function to auth.ts

### DIFF
--- a/web-server/src/utils/auth.ts
+++ b/web-server/src/utils/auth.ts
@@ -33,3 +33,22 @@ export async function checkGitHubValidity(
     return false;
   }
 }
+
+const PAT_SCOPES = ['read:org', 'read:user', 'repo', 'workflow', 'xzczcx'];
+export const getMissingPATScopes = async (pat: string) => {
+  try {
+    const response = await axios.get('https://api.github.com', {
+      headers: {
+        Authorization: `token ${pat}`
+      }
+    });
+
+    const scopesString = response.headers['x-oauth-scopes'];
+    if (!scopesString) return PAT_SCOPES;
+
+    const userScopes = scopesString.split(',').map((scope) => scope.trim());
+    return PAT_SCOPES.filter((scope) => !userScopes.includes(scope));
+  } catch (error) {
+    return PAT_SCOPES;
+  }
+};


### PR DESCRIPTION
This pull request adds the getMissingPATScopes function to the auth.ts file. This function is used to check for missing scopes in a personal access token (PAT). It makes a request to the GitHub API to retrieve the scopes associated with the provided PAT and compares them to a predefined list of scopes. If any scopes are missing, the function returns the missing scopes.