### PR TITLE
Make pat-permissions image responsive

### DIFF
--- a/web-server/src/content/Dashboards/useIntegrationHandlers.tsx
+++ b/web-server/src/content/Dashboards/useIntegrationHandlers.tsx
@@ -190,12 +190,13 @@ const TokenPermissions = () => {
 
   const styles: SxProps[] = useMemo(() => {
     const baseStyles = {
-      border: `2px solid ${alpha('rgb(256,0,0)', 0.6)}`,
+      border: `2px solid ${alpha('rgb(256,0,0)', 0.4)}`,
       transition: 'all 0.8s ease',
       borderRadius: '12px',
       opacity: expand.value ? 0 : 1,
-      width: '770px',
+      width: '240px',
       position: 'absolute',
+      maxWidth: 'calc(100% - 48px)',
       left: '24px'
     };
 
@@ -221,12 +222,13 @@ const TokenPermissions = () => {
 
   const expandedStyles = useMemo(() => {
     const baseStyles = {
-      border: `2px solid ${alpha('rgb(256,0,0)', 0.6)}`,
+      border: `2px solid ${alpha('rgb(256,0,0)', 0.4)}`,
       transition: 'all 0.8s ease',
       borderRadius: '12px',
       opacity: !expand.value ? 0 : 1,
-      width: '770px',
+      width: '240px',
       position: 'absolute',
+      maxWidth: 'calc(100% - 48px)',
       left: '24px'
     };
 
@@ -253,7 +255,7 @@ const TokenPermissions = () => {
   }, [expand.value]);
 
   return (
-    <FlexBox col gap1>
+    <FlexBox col gap1 maxWidth={'100%'} overflow={'auto'}>
       <div
         onMouseEnter={expand.true}
         onMouseLeave={expand.false}
@@ -262,7 +264,8 @@ const TokenPermissions = () => {
           borderRadius: '12px',
           height: expand.value ? '1257px' : '240px',
           transition: 'all 0.8s ease',
-          position: 'relative'
+          position: 'relative',
+          maxWidth: '100%'
         }}
       >
         <Image


### PR DESCRIPTION
This pull request makes the pat-permissions image responsive by adjusting the width and max-width properties. The border color and opacity are also modified for better visual consistency.

https://github.com/middlewarehq/middleware/assets/76566992/1a564d3b-da6c-48e6-b39e-32d98cec002c

