### PR TITLE
Add useRedirectWithSession hook to dora-metrics and teams pages

### DIFF
--- a/web-server/pages/dora-metrics/index.tsx
+++ b/web-server/pages/dora-metrics/index.tsx
@@ -4,12 +4,14 @@ import ExtendedSidebarLayout from 'src/layouts/ExtendedSidebarLayout';
 import { Authenticated } from '@/components/Authenticated';
 import { FlexBox } from '@/components/FlexBox';
 import { FetchState } from '@/constants/ui-states';
+import { useRedirectWithSession } from '@/constants/useRoute';
 import { DoraMetricsBody } from '@/content/DoraMetrics/DoraMetricsBody';
 import { PageWrapper } from '@/content/PullRequests/PageWrapper';
 import { useSelector } from '@/store';
 import { PageLayout } from '@/types/resources';
 
 function Page() {
+  useRedirectWithSession();
   const isLoading = useSelector(
     (s) => s.doraMetrics.requests?.metrics_summary === FetchState.REQUEST
   );

--- a/web-server/pages/teams/index.tsx
+++ b/web-server/pages/teams/index.tsx
@@ -6,6 +6,7 @@ import { FlexBox } from '@/components/FlexBox';
 import { CreateEditTeams } from '@/components/Teams/CreateTeams';
 import { TeamsList } from '@/components/TeamsList';
 import { Integration } from '@/constants/integrations';
+import { useRedirectWithSession } from '@/constants/useRoute';
 import { PageWrapper } from '@/content/PullRequests/PageWrapper';
 import { useAuth } from '@/hooks/useAuth';
 import { fetchTeams } from '@/slices/team';
@@ -13,6 +14,7 @@ import { useDispatch, useSelector } from '@/store';
 import { PageLayout } from '@/types/resources';
 
 function Page() {
+  useRedirectWithSession();
   const dispatch = useDispatch();
   const { orgId } = useAuth();
   const teamsList = useSelector((state) => state.team.teams);


### PR DESCRIPTION
This pull request adds the useRedirectWithSession hook to the dora-metrics and teams pages. The hook ensures that the user is redirected to the appropriate page after a session is created.