### PR TITLE
Add orgRepos to FetchTeamsResponse

### DIFF
--- a/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
+++ b/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
@@ -68,6 +68,7 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
       dispatch(
         appSlice.actions.setTeamProdBranchMap(res.data.teamReposProdBranchMap)
       );
+      dispatch(teamSlice.actions.setOrgRepos(res.data.orgRepos));
       const teams = res.data.teams.filter((t) => t.id);
 
       const singleT = teams.find((team) => singleTeamId === team.id);

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -614,6 +614,7 @@ export type FetchTeamsResponse = {
   teams: Team[];
   teamReposProdBranchMap: Record<ID, TeamRepoBranchDetails[]>;
   teamReposMap: Record<ID, DB_OrgRepo[]>;
+  orgRepos: BaseRepo[];
 };
 
 export type FetchTeamSettingsAPIResponse<T extends {} = {}> = {


### PR DESCRIPTION
This pull request adds the `orgRepos` property to the `FetchTeamsResponse` type, which represents the repositories of the organization.
Fixes the team-repos not loading in the edit-team overlay when using from dora-page