### PR TITLE
build only arm images since it is only failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/arm64]
     
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,25 +9,20 @@ jobs:
 
   build-and-push:
     name: Build and Push Docker Image
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted-arm-64
     strategy:
       matrix:
-        os: [macos-13]
         platform: [linux/arm64]
-
+    
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
         
-      - name: setup docker for mac
-        uses: douglascamata/setup-docker-macos-action@v1-alpha
-        
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,35 +9,39 @@ jobs:
 
   build-and-push:
     name: Build and Push Docker Image
-    runs-on: self-hosted-arm-64
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        platform: [linux/arm64]
-    
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: self-hosted-arm-64
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-        
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: middlewareeng/middleware
-          
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,20 +9,25 @@ jobs:
 
   build-and-push:
     name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-13]
         platform: [linux/arm64]
-    
+
     steps:
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
         
+      - name: setup docker for mac
+        uses: douglascamata/setup-docker-macos-action@v1-alpha
+        
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN apt-get update && \
     && crontab /etc/cron.d/cronjob \
     && /app/setup_utils/generate_config_ini.sh -t /app/backend/analytics_server/mhq/config \
     && cd /app/web-server \
-    && npm install --network-timeout 1000000 --force && npm run build \
+    && npm install --force && npm run build \
     && rm -rf ./artifacts \
     && cd /app/ \
     && tar cfz web-server.tar.gz ./web-server \

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,14 +86,14 @@ RUN apt-get update && \
     && crontab /etc/cron.d/cronjob \
     && /app/setup_utils/generate_config_ini.sh -t /app/backend/analytics_server/mhq/config \
     && cd /app/web-server \
-    && yarn install --network-timeout 1000000 && yarn build \
+    && npm install --network-timeout 1000000 && npm run build \
     && rm -rf ./artifacts \
     && cd /app/ \
     && tar cfz web-server.tar.gz ./web-server \
     && rm -rf ./web-server && mkdir -p /app/web-server \
     && tar cfz /opt/venv.tar.gz /opt/venv/ \
     && rm -rf /opt/venv && mkdir -p /opt/venv \
-    && yarn cache clean \
+    && npm cache clean --force\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,14 +86,14 @@ RUN apt-get update && \
     && crontab /etc/cron.d/cronjob \
     && /app/setup_utils/generate_config_ini.sh -t /app/backend/analytics_server/mhq/config \
     && cd /app/web-server \
-    && npm install --force && npm run build \
+    && yarn install --network-timeout 1000000 && yarn build \
     && rm -rf ./artifacts \
     && cd /app/ \
     && tar cfz web-server.tar.gz ./web-server \
     && rm -rf ./web-server && mkdir -p /app/web-server \
     && tar cfz /opt/venv.tar.gz /opt/venv/ \
     && rm -rf /opt/venv && mkdir -p /opt/venv \
-    && npm cache clean --force\
+    && yarn cache clean \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN apt-get update && \
     && crontab /etc/cron.d/cronjob \
     && /app/setup_utils/generate_config_ini.sh -t /app/backend/analytics_server/mhq/config \
     && cd /app/web-server \
-    && npm install --network-timeout 1000000 && npm run build \
+    && npm install --network-timeout 1000000 --force && npm run build \
     && rm -rf ./artifacts \
     && cd /app/ \
     && tar cfz web-server.tar.gz ./web-server \

--- a/web-server/next.config.js
+++ b/web-server/next.config.js
@@ -49,6 +49,7 @@ const genericPlugins = [
 ];
 
 const staticOverrides = {
+  staticPageGenerationTimeout: 2000,
   images: {
     disableStaticImages: true
   },


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
Closes #200 
## Summary

This pull request introduces changes to the Docker image publishing workflow, allowing for more efficient builds and deployments across different architectures.

## Changes

- **Improved Build Infrastructure**: We have integrated a self-hosted arm64 runner for building and deploying Docker images for the `linux/arm64` platform. This runner provides better performance and compatibility for arm64 architecture builds.

- **Optimized Build Matrix**: The workflow now utilizes a build matrix strategy to dynamically select the appropriate runner based on the target platform. For `linux/amd64` builds, we continue to leverage the `ubuntu-latest` runner provided by GitHub Actions, ensuring a consistent and reliable environment.

## Benefits

The integration of the self-hosted arm64 runner has significantly reduced the build time for arm64 Docker images. The build time has decreased from approximately 1 hour and 30 minutes to around 9 minutes, resulting in a substantial improvement in overall build efficiency.

