### PR TITLE
Add unit tests for mean time to recovery APIs

### DIFF
--- a/backend/analytics_server/mhq/service/incidents/incidents.py
+++ b/backend/analytics_server/mhq/service/incidents/incidents.py
@@ -113,24 +113,9 @@ class IncidentService:
 
         resolved_team_incidents = self.get_resolved_team_incidents(team_id, interval)
 
-        weekly_resolved_team_incidents: Dict[
-            datetime, List[Incident]
-        ] = generate_expanded_buckets(
-            resolved_team_incidents, interval, "resolved_date", "weekly"
+        return self._get_incidents_mean_time_to_recovery_trends(
+            resolved_team_incidents, interval
         )
-
-        weekly_mean_time_to_recovery: Dict[datetime, MeanTimeToRecoveryMetrics] = {}
-
-        for week, incidents in weekly_resolved_team_incidents.items():
-
-            if incidents:
-                weekly_mean_time_to_recovery[
-                    week
-                ] = self._get_incidents_mean_time_to_recovery(incidents)
-            else:
-                weekly_mean_time_to_recovery[week] = MeanTimeToRecoveryMetrics()
-
-        return weekly_mean_time_to_recovery
 
     def calculate_change_failure_deployments(
         self, deployment_incidents_map: Dict[Deployment, List[Incident]]
@@ -207,6 +192,29 @@ class IncidentService:
         )
 
         return MeanTimeToRecoveryMetrics(mean_time_to_recovery, incident_count)
+
+    def _get_incidents_mean_time_to_recovery_trends(
+        self, resolved_incidents: List[Incident], interval: Interval
+    ) -> Dict[datetime, MeanTimeToRecoveryMetrics]:
+
+        weekly_resolved_team_incidents: Dict[
+            datetime, List[Incident]
+        ] = generate_expanded_buckets(
+            resolved_incidents, interval, "resolved_date", "weekly"
+        )
+
+        weekly_mean_time_to_recovery: Dict[datetime, MeanTimeToRecoveryMetrics] = {}
+
+        for week, incidents in weekly_resolved_team_incidents.items():
+
+            if incidents:
+                weekly_mean_time_to_recovery[
+                    week
+                ] = self._get_incidents_mean_time_to_recovery(incidents)
+            else:
+                weekly_mean_time_to_recovery[week] = MeanTimeToRecoveryMetrics()
+
+        return weekly_mean_time_to_recovery
 
 
 def get_incident_service():

--- a/backend/analytics_server/tests/factories/models/incidents.py
+++ b/backend/analytics_server/tests/factories/models/incidents.py
@@ -3,7 +3,10 @@ from typing import List, Set
 
 from voluptuous import default_factory
 from mhq.service.deployments.models.models import Deployment
-from mhq.service.incidents.models.mean_time_to_recovery import ChangeFailureRateMetrics, MeanTimeToRecoveryMetrics
+from mhq.service.incidents.models.mean_time_to_recovery import (
+    ChangeFailureRateMetrics,
+    MeanTimeToRecoveryMetrics,
+)
 
 from mhq.store.models.incidents import IncidentType, OrgIncidentService
 from mhq.store.models.incidents.incidents import (
@@ -92,12 +95,8 @@ def get_change_failure_rate_metrics(
 ):
     return ChangeFailureRateMetrics(failed_deployments, total_deployments)
 
+
 def get_mean_time_to_recovery_metrics(
-    mean_time_to_recovery: int = None,
-    incident_count: int = None
-    )->MeanTimeToRecoveryMetrics:
-    return MeanTimeToRecoveryMetrics(
-        mean_time_to_recovery,
-        incident_count
-    )
-    
+    mean_time_to_recovery: int = None, incident_count: int = None
+) -> MeanTimeToRecoveryMetrics:
+    return MeanTimeToRecoveryMetrics(mean_time_to_recovery, incident_count)

--- a/backend/analytics_server/tests/factories/models/incidents.py
+++ b/backend/analytics_server/tests/factories/models/incidents.py
@@ -100,3 +100,4 @@ def get_mean_time_to_recovery_metrics(
         mean_time_to_recovery,
         incident_count
     )
+    

--- a/backend/analytics_server/tests/factories/models/incidents.py
+++ b/backend/analytics_server/tests/factories/models/incidents.py
@@ -3,7 +3,7 @@ from typing import List, Set
 
 from voluptuous import default_factory
 from mhq.service.deployments.models.models import Deployment
-from mhq.service.incidents.models.mean_time_to_recovery import ChangeFailureRateMetrics
+from mhq.service.incidents.models.mean_time_to_recovery import ChangeFailureRateMetrics, MeanTimeToRecoveryMetrics
 
 from mhq.store.models.incidents import IncidentType, OrgIncidentService
 from mhq.store.models.incidents.incidents import (
@@ -91,3 +91,12 @@ def get_change_failure_rate_metrics(
     total_deployments: Set[Deployment] = None,
 ):
     return ChangeFailureRateMetrics(failed_deployments, total_deployments)
+
+def get_mean_time_to_recovery_metrics(
+    mean_time_to_recovery: int = None,
+    incident_count: int = None
+    )->MeanTimeToRecoveryMetrics:
+    return MeanTimeToRecoveryMetrics(
+        mean_time_to_recovery,
+        incident_count
+    )

--- a/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
+++ b/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
@@ -13,68 +13,125 @@ second_week_2024 = datetime(2024, 1, 8, 0, 0, 0, tzinfo=pytz.UTC)
 third_week_2024 = datetime(2024, 1, 15, 0, 0, 0, tzinfo=pytz.UTC)
 fourth_week_2024 = datetime(2024, 1, 22, 0, 0, 0, tzinfo=pytz.UTC)
 
+
 def test_get_incidents_mean_time_to_recovery_for_no_incidents():
-    
-    incident_service = IncidentService(None,None)
+
+    incident_service = IncidentService(None, None)
     incidents = []
     mean_time_to_recovery = incident_service._get_incidents_mean_time_to_recovery([])
-    
-    assert get_mean_time_to_recovery_metrics(None,0) == mean_time_to_recovery
+
+    assert get_mean_time_to_recovery_metrics(None, 0) == mean_time_to_recovery
 
 
 def test_get_incidents_mean_time_to_recovery_for_incidents():
-    
-    incident_service = IncidentService(None,None)
-    
-    incident_1 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=100))
-    incident_2 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=300))
-    incident_3 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=800))
-    incident_4 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=90))
-    
-    
-    assert  get_mean_time_to_recovery_metrics(400,3) == incident_service._get_incidents_mean_time_to_recovery(
+
+    incident_service = IncidentService(None, None)
+
+    incident_1 = get_incident(
+        creation_date=first_week_2024,
+        resolved_date=first_week_2024 + timedelta(seconds=100),
+    )
+    incident_2 = get_incident(
+        creation_date=first_week_2024,
+        resolved_date=first_week_2024 + timedelta(seconds=300),
+    )
+    incident_3 = get_incident(
+        creation_date=first_week_2024,
+        resolved_date=first_week_2024 + timedelta(seconds=800),
+    )
+    incident_4 = get_incident(
+        creation_date=first_week_2024,
+        resolved_date=first_week_2024 + timedelta(seconds=90),
+    )
+
+    assert get_mean_time_to_recovery_metrics(
+        400, 3
+    ) == incident_service._get_incidents_mean_time_to_recovery(
         [incident_1, incident_2, incident_3]
     )
-    
-    assert  get_mean_time_to_recovery_metrics(322.5,4) == incident_service._get_incidents_mean_time_to_recovery(
+
+    assert get_mean_time_to_recovery_metrics(
+        322.5, 4
+    ) == incident_service._get_incidents_mean_time_to_recovery(
         [incident_1, incident_2, incident_3, incident_4]
     )
 
 
 def test_get_deployment_incidents_count_map_returns_empty_dict_when_given_some_incidents_no_deployments():
     incident_service = get_incident_service()
-    mean_time_to_recovery_trends = incident_service._get_incidents_mean_time_to_recovery_trends(
-        [],
-        Interval(first_week_2024, third_week_2024 + timedelta(seconds= 20)),
+    mean_time_to_recovery_trends = (
+        incident_service._get_incidents_mean_time_to_recovery_trends(
+            [],
+            Interval(first_week_2024, third_week_2024 + timedelta(seconds=20)),
+        )
     )
-    assert mean_time_to_recovery_trends == { first_week_2024: get_mean_time_to_recovery_metrics(None, 0),second_week_2024: get_mean_time_to_recovery_metrics(None, 0),third_week_2024: get_mean_time_to_recovery_metrics(None, 0)}
+    assert mean_time_to_recovery_trends == {
+        first_week_2024: get_mean_time_to_recovery_metrics(None, 0),
+        second_week_2024: get_mean_time_to_recovery_metrics(None, 0),
+        third_week_2024: get_mean_time_to_recovery_metrics(None, 0),
+    }
 
 
 def test_get_change_failure_rate_for_one_incidents_bw_two_deployments():
-    
+
     incident_service = get_incident_service()
-    
+
     from_time = first_week_2024
     to_time = fourth_week_2024
-    
 
     # Week 1
-    incident_0 = get_incident(creation_date=from_time + timedelta(hours=10),resolved_date= from_time + timedelta(hours=10, seconds=100))
+    incident_0 = get_incident(
+        creation_date=from_time + timedelta(hours=10),
+        resolved_date=from_time + timedelta(hours=10, seconds=100),
+    )
 
-    incident_1 = get_incident(creation_date=from_time + timedelta(hours=28), resolved_date= from_time + timedelta(hours=28, seconds=100))
-    incident_2 = get_incident(creation_date=from_time + timedelta(hours=29), resolved_date= from_time + timedelta(hours=29, seconds=400))
+    incident_1 = get_incident(
+        creation_date=from_time + timedelta(hours=28),
+        resolved_date=from_time + timedelta(hours=28, seconds=100),
+    )
+    incident_2 = get_incident(
+        creation_date=from_time + timedelta(hours=29),
+        resolved_date=from_time + timedelta(hours=29, seconds=400),
+    )
 
     # Week 3
-    incident_3 = get_incident(creation_date=third_week_2024 + timedelta(days=2), resolved_date= third_week_2024 +timedelta(days=2, seconds=100))
-    incident_4 = get_incident(creation_date=third_week_2024 + timedelta(days=4), resolved_date= third_week_2024 +timedelta(days=4, seconds=100))
-    incident_5 = get_incident(creation_date=third_week_2024 + timedelta(days=4), resolved_date= third_week_2024 +timedelta(days=4, seconds=100))
-    incident_6 = get_incident(creation_date=third_week_2024 + timedelta(days=3), resolved_date= third_week_2024 +timedelta(days=3, seconds=100))
-    
-    mean_time_to_recovery_trends = incident_service._get_incidents_mean_time_to_recovery_trends(
-        [incident_0, incident_1, incident_2, incident_3, incident_4, incident_5, incident_6],
-        Interval(from_time, to_time),
+    incident_3 = get_incident(
+        creation_date=third_week_2024 + timedelta(days=2),
+        resolved_date=third_week_2024 + timedelta(days=2, seconds=100),
+    )
+    incident_4 = get_incident(
+        creation_date=third_week_2024 + timedelta(days=4),
+        resolved_date=third_week_2024 + timedelta(days=4, seconds=100),
+    )
+    incident_5 = get_incident(
+        creation_date=third_week_2024 + timedelta(days=4),
+        resolved_date=third_week_2024 + timedelta(days=4, seconds=100),
+    )
+    incident_6 = get_incident(
+        creation_date=third_week_2024 + timedelta(days=3),
+        resolved_date=third_week_2024 + timedelta(days=3, seconds=100),
+    )
+
+    mean_time_to_recovery_trends = (
+        incident_service._get_incidents_mean_time_to_recovery_trends(
+            [
+                incident_0,
+                incident_1,
+                incident_2,
+                incident_3,
+                incident_4,
+                incident_5,
+                incident_6,
+            ],
+            Interval(from_time, to_time),
+        )
     )
 
     print(mean_time_to_recovery_trends)
-        
-    assert mean_time_to_recovery_trends == { first_week_2024: get_mean_time_to_recovery_metrics(200, 3),second_week_2024: get_mean_time_to_recovery_metrics(None, 0),third_week_2024: get_mean_time_to_recovery_metrics(100, 4), fourth_week_2024: get_mean_time_to_recovery_metrics(None, 0)}
+
+    assert mean_time_to_recovery_trends == {
+        first_week_2024: get_mean_time_to_recovery_metrics(200, 3),
+        second_week_2024: get_mean_time_to_recovery_metrics(None, 0),
+        third_week_2024: get_mean_time_to_recovery_metrics(100, 4),
+        fourth_week_2024: get_mean_time_to_recovery_metrics(None, 0),
+    }

--- a/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
+++ b/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
@@ -157,8 +157,6 @@ def test_get_change_failure_rate_for_one_incidents_bw_two_deployments():
         )
     )
 
-    print(mean_time_to_recovery_trends)
-
     assert mean_time_to_recovery_trends == {
         first_week_2024: get_mean_time_to_recovery_metrics(
             (

--- a/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
+++ b/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
@@ -78,6 +78,3 @@ def test_get_change_failure_rate_for_one_incidents_bw_two_deployments():
     print(mean_time_to_recovery_trends)
         
     assert mean_time_to_recovery_trends == { first_week_2024: get_mean_time_to_recovery_metrics(200, 3),second_week_2024: get_mean_time_to_recovery_metrics(None, 0),third_week_2024: get_mean_time_to_recovery_metrics(100, 4), fourth_week_2024: get_mean_time_to_recovery_metrics(None, 0)}
-
-
-    

--- a/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
+++ b/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
@@ -1,0 +1,83 @@
+import pytz
+from datetime import datetime
+from datetime import timedelta
+from tests.factories.models.incidents import get_mean_time_to_recovery_metrics
+from mhq.service.incidents.incidents import get_incident_service, IncidentService
+from mhq.utils.time import Interval
+
+from tests.factories.models import get_incident
+
+
+first_week_2024 = datetime(2024, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
+second_week_2024 = datetime(2024, 1, 8, 0, 0, 0, tzinfo=pytz.UTC)
+third_week_2024 = datetime(2024, 1, 15, 0, 0, 0, tzinfo=pytz.UTC)
+fourth_week_2024 = datetime(2024, 1, 22, 0, 0, 0, tzinfo=pytz.UTC)
+
+def test_get_incidents_mean_time_to_recovery_for_no_incidents():
+    
+    incident_service = IncidentService(None,None)
+    incidents = []
+    mean_time_to_recovery = incident_service._get_incidents_mean_time_to_recovery([])
+    
+    assert get_mean_time_to_recovery_metrics(None,0) == mean_time_to_recovery
+
+
+def test_get_incidents_mean_time_to_recovery_for_incidents():
+    
+    incident_service = IncidentService(None,None)
+    
+    incident_1 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=100))
+    incident_2 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=300))
+    incident_3 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=800))
+    incident_4 = get_incident(creation_date=first_week_2024, resolved_date=first_week_2024 + timedelta(seconds=90))
+    
+    
+    assert  get_mean_time_to_recovery_metrics(400,3) == incident_service._get_incidents_mean_time_to_recovery(
+        [incident_1, incident_2, incident_3]
+    )
+    
+    assert  get_mean_time_to_recovery_metrics(322.5,4) == incident_service._get_incidents_mean_time_to_recovery(
+        [incident_1, incident_2, incident_3, incident_4]
+    )
+
+
+def test_get_deployment_incidents_count_map_returns_empty_dict_when_given_some_incidents_no_deployments():
+    incident_service = get_incident_service()
+    mean_time_to_recovery_trends = incident_service._get_incidents_mean_time_to_recovery_trends(
+        [],
+        Interval(first_week_2024, third_week_2024 + timedelta(seconds= 20)),
+    )
+    assert mean_time_to_recovery_trends == { first_week_2024: get_mean_time_to_recovery_metrics(None, 0),second_week_2024: get_mean_time_to_recovery_metrics(None, 0),third_week_2024: get_mean_time_to_recovery_metrics(None, 0)}
+
+
+def test_get_change_failure_rate_for_one_incidents_bw_two_deployments():
+    
+    incident_service = get_incident_service()
+    
+    from_time = first_week_2024
+    to_time = fourth_week_2024
+    
+
+    # Week 1
+    incident_0 = get_incident(creation_date=from_time + timedelta(hours=10),resolved_date= from_time + timedelta(hours=10, seconds=100))
+
+    incident_1 = get_incident(creation_date=from_time + timedelta(hours=28), resolved_date= from_time + timedelta(hours=28, seconds=100))
+    incident_2 = get_incident(creation_date=from_time + timedelta(hours=29), resolved_date= from_time + timedelta(hours=29, seconds=400))
+
+    # Week 3
+    incident_3 = get_incident(creation_date=third_week_2024 + timedelta(days=2), resolved_date= third_week_2024 +timedelta(days=2, seconds=100))
+    incident_4 = get_incident(creation_date=third_week_2024 + timedelta(days=4), resolved_date= third_week_2024 +timedelta(days=4, seconds=100))
+    incident_5 = get_incident(creation_date=third_week_2024 + timedelta(days=4), resolved_date= third_week_2024 +timedelta(days=4, seconds=100))
+    incident_6 = get_incident(creation_date=third_week_2024 + timedelta(days=3), resolved_date= third_week_2024 +timedelta(days=3, seconds=100))
+    
+    mean_time_to_recovery_trends = incident_service._get_incidents_mean_time_to_recovery_trends(
+        [incident_0, incident_1, incident_2, incident_3, incident_4, incident_5, incident_6],
+        Interval(from_time, to_time),
+    )
+
+    print(mean_time_to_recovery_trends)
+        
+    assert mean_time_to_recovery_trends == { first_week_2024: get_mean_time_to_recovery_metrics(200, 3),second_week_2024: get_mean_time_to_recovery_metrics(None, 0),third_week_2024: get_mean_time_to_recovery_metrics(100, 4), fourth_week_2024: get_mean_time_to_recovery_metrics(None, 0)}
+
+
+    

--- a/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
+++ b/backend/analytics_server/tests/service/Incidents/test_mean_time_to_recovery.py
@@ -17,7 +17,6 @@ fourth_week_2024 = datetime(2024, 1, 22, 0, 0, 0, tzinfo=pytz.UTC)
 def test_get_incidents_mean_time_to_recovery_for_no_incidents():
 
     incident_service = IncidentService(None, None)
-    incidents = []
     mean_time_to_recovery = incident_service._get_incidents_mean_time_to_recovery([])
 
     assert get_mean_time_to_recovery_metrics(None, 0) == mean_time_to_recovery
@@ -27,31 +26,51 @@ def test_get_incidents_mean_time_to_recovery_for_incidents():
 
     incident_service = IncidentService(None, None)
 
+    incident_1_resolution_time = timedelta(seconds=100)
     incident_1 = get_incident(
         creation_date=first_week_2024,
-        resolved_date=first_week_2024 + timedelta(seconds=100),
+        resolved_date=first_week_2024 + incident_1_resolution_time,
     )
+
+    incident_2_resolution_time = timedelta(seconds=300)
     incident_2 = get_incident(
         creation_date=first_week_2024,
-        resolved_date=first_week_2024 + timedelta(seconds=300),
+        resolved_date=first_week_2024 + incident_2_resolution_time,
     )
+
+    incident_3_resolution_time = timedelta(seconds=800)
     incident_3 = get_incident(
         creation_date=first_week_2024,
-        resolved_date=first_week_2024 + timedelta(seconds=800),
+        resolved_date=first_week_2024 + incident_3_resolution_time,
     )
+
+    incident_4_resolution_time = timedelta(seconds=90)
     incident_4 = get_incident(
         creation_date=first_week_2024,
-        resolved_date=first_week_2024 + timedelta(seconds=90),
+        resolved_date=first_week_2024 + incident_4_resolution_time,
     )
 
     assert get_mean_time_to_recovery_metrics(
-        400, 3
+        (
+            incident_1_resolution_time.seconds
+            + incident_2_resolution_time.seconds
+            + incident_3_resolution_time.seconds
+        )
+        / 3,
+        3,
     ) == incident_service._get_incidents_mean_time_to_recovery(
         [incident_1, incident_2, incident_3]
     )
 
     assert get_mean_time_to_recovery_metrics(
-        322.5, 4
+        (
+            incident_1_resolution_time.seconds
+            + incident_2_resolution_time.seconds
+            + incident_3_resolution_time.seconds
+            + incident_4_resolution_time.seconds
+        )
+        / 4,
+        4,
     ) == incident_service._get_incidents_mean_time_to_recovery(
         [incident_1, incident_2, incident_3, incident_4]
     )
@@ -80,36 +99,47 @@ def test_get_change_failure_rate_for_one_incidents_bw_two_deployments():
     to_time = fourth_week_2024
 
     # Week 1
+    incident_0_resolution_time = timedelta(seconds=100)
     incident_0 = get_incident(
         creation_date=from_time + timedelta(hours=10),
-        resolved_date=from_time + timedelta(hours=10, seconds=100),
+        resolved_date=from_time + timedelta(hours=10) + incident_0_resolution_time,
     )
 
+    incident_1_resolution_time = timedelta(seconds=100)
     incident_1 = get_incident(
         creation_date=from_time + timedelta(hours=28),
-        resolved_date=from_time + timedelta(hours=28, seconds=100),
+        resolved_date=from_time + timedelta(hours=28) + incident_1_resolution_time,
     )
+
+    incident_2_resolution_time = timedelta(seconds=400)
     incident_2 = get_incident(
         creation_date=from_time + timedelta(hours=29),
-        resolved_date=from_time + timedelta(hours=29, seconds=400),
+        resolved_date=from_time + timedelta(hours=29) + incident_2_resolution_time,
     )
 
     # Week 3
+    incident_3_resolution_time = timedelta(seconds=100)
     incident_3 = get_incident(
         creation_date=third_week_2024 + timedelta(days=2),
-        resolved_date=third_week_2024 + timedelta(days=2, seconds=100),
+        resolved_date=third_week_2024 + timedelta(days=2) + incident_3_resolution_time,
     )
+
+    incident_4_resolution_time = timedelta(seconds=100)
     incident_4 = get_incident(
         creation_date=third_week_2024 + timedelta(days=4),
-        resolved_date=third_week_2024 + timedelta(days=4, seconds=100),
+        resolved_date=third_week_2024 + timedelta(days=4) + incident_4_resolution_time,
     )
+
+    incident_5_resolution_time = timedelta(seconds=100)
     incident_5 = get_incident(
         creation_date=third_week_2024 + timedelta(days=4),
-        resolved_date=third_week_2024 + timedelta(days=4, seconds=100),
+        resolved_date=third_week_2024 + timedelta(days=4) + incident_5_resolution_time,
     )
+
+    incident_6_resolution_time = timedelta(seconds=100)
     incident_6 = get_incident(
         creation_date=third_week_2024 + timedelta(days=3),
-        resolved_date=third_week_2024 + timedelta(days=3, seconds=100),
+        resolved_date=third_week_2024 + timedelta(days=3) + incident_6_resolution_time,
     )
 
     mean_time_to_recovery_trends = (
@@ -130,8 +160,25 @@ def test_get_change_failure_rate_for_one_incidents_bw_two_deployments():
     print(mean_time_to_recovery_trends)
 
     assert mean_time_to_recovery_trends == {
-        first_week_2024: get_mean_time_to_recovery_metrics(200, 3),
+        first_week_2024: get_mean_time_to_recovery_metrics(
+            (
+                incident_0_resolution_time.seconds
+                + incident_1_resolution_time.seconds
+                + incident_2_resolution_time.seconds
+            )
+            / 3,
+            3,
+        ),
         second_week_2024: get_mean_time_to_recovery_metrics(None, 0),
-        third_week_2024: get_mean_time_to_recovery_metrics(100, 4),
+        third_week_2024: get_mean_time_to_recovery_metrics(
+            (
+                incident_3_resolution_time.seconds
+                + incident_4_resolution_time.seconds
+                + incident_5_resolution_time.seconds
+                + incident_6_resolution_time.seconds
+            )
+            / 4,
+            4,
+        ),
         fourth_week_2024: get_mean_time_to_recovery_metrics(None, 0),
     }


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
Closes #205

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [x] Added test for MTTR and MTTR trends 
- [x] Updated code to have pure funcs and tested code

## Proposed changes (including videos or screenshots)

- Refactored Code for MTTR metrics into pure funcs
- Added factory method for MeanTimeToRecoveryMetrics
- Added tests for MTTR aggregate: data absence, integer and floating values
- Added tests for MTTR trends:  missing week data, floating and int values.

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
