### PR TITLE
Fix null acesssing of state_changed_at

### DIFF
--- a/backend/analytics_server/mhq/service/code/sync/etl_handler.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_handler.py
@@ -66,8 +66,10 @@ class CodeETLHandler:
             )
             if not pull_requests:
                 return
+
+            pull_requests.sort(key=lambda x: x.updated_at)
             bookmark.bookmark = (
-                pull_requests[-1].state_changed_at.astimezone(tz=pytz.UTC).isoformat()
+                pull_requests[-1].updated_at.astimezone(tz=pytz.UTC).isoformat()
             )
             bookmark.updated_at = time_now()
             self.code_repo_service.update_org_repo_bookmark(bookmark)


### PR DESCRIPTION
## Linked Issue(s) 

closes #220 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [x] Fixes null access of state changed at and bookmark now relies on updated_at


## Proposed changes (including videos or screenshots)

- sort prs and set updated_at of last pr as bookmark

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
