### PR TITLE
Fixes incorrect redirect on teams-page

### DIFF
--- a/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
+++ b/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
@@ -46,7 +46,6 @@ endpoint.handle.GET(getSchema, async (req, res) => {
     from_date: rawFromDate,
     to_date: rawToDate,
     branches,
-    repo_filters
   } = req.payload;
 
   const teamProdBranchesMap =

--- a/web-server/pages/teams/index.tsx
+++ b/web-server/pages/teams/index.tsx
@@ -1,33 +1,41 @@
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import ExtendedSidebarLayout from 'src/layouts/ExtendedSidebarLayout';
 
-import { Authenticated } from '@/components/Authenticated';
 import { FlexBox } from '@/components/FlexBox';
-import { CreateEditTeams } from '@/components/Teams/CreateTeams';
+import { CreateEditTeams, Loader } from '@/components/Teams/CreateTeams';
 import { TeamsList } from '@/components/TeamsList';
 import { Integration } from '@/constants/integrations';
-import { useRedirectWithSession } from '@/constants/useRoute';
+import { ROUTES } from '@/constants/routes';
 import { PageWrapper } from '@/content/PullRequests/PageWrapper';
 import { useAuth } from '@/hooks/useAuth';
 import { fetchTeams } from '@/slices/team';
 import { useDispatch, useSelector } from '@/store';
 import { PageLayout } from '@/types/resources';
+import { depFn } from '@/utils/fn';
 
 function Page() {
-  useRedirectWithSession();
   const dispatch = useDispatch();
-  const { orgId } = useAuth();
+  const {
+    orgId,
+    integrations: { github: isGithubIntegrated }
+  } = useAuth();
   const teamsList = useSelector((state) => state.team.teams);
+  const router = useRouter();
 
   useEffect(() => {
     if (!orgId) return;
+    if (!isGithubIntegrated) {
+      depFn(router.replace, ROUTES.INTEGRATIONS.PATH);
+      return;
+    }
     dispatch(
       fetchTeams({
         org_id: orgId,
         provider: Integration.GITHUB
       })
     );
-  }, [dispatch, orgId]);
+  }, [dispatch, isGithubIntegrated, orgId, router.replace]);
 
   return (
     <PageWrapper
@@ -40,17 +48,19 @@ function Page() {
       showEvenIfNoTeamSelected
       hideAllSelectors
     >
-      <FlexBox col gap={4}>
-        {teamsList.length ? <TeamsList /> : <CreateEditTeams />}
-      </FlexBox>
+      {isGithubIntegrated ? (
+        <FlexBox col gap={4}>
+          {teamsList.length ? <TeamsList /> : <CreateEditTeams />}
+        </FlexBox>
+      ) : (
+        <Loader />
+      )}
     </PageWrapper>
   );
 }
 
 Page.getLayout = (page: PageLayout) => (
-  <Authenticated>
-    <ExtendedSidebarLayout>{page}</ExtendedSidebarLayout>
-  </Authenticated>
+  <ExtendedSidebarLayout>{page}</ExtendedSidebarLayout>
 );
 
 export default Page;

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -73,7 +73,7 @@ const TeamsCRUD: FC<CRUDProps> = ({
   );
 };
 
-const Loader = () => {
+export const Loader = () => {
   return (
     <FlexBox alignCenter gap2>
       <CircularProgress size="20px" />

--- a/web-server/src/constants/useRoute.ts
+++ b/web-server/src/constants/useRoute.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { OnboardingStep, UserRole } from '@/types/resources';
+import { depFn } from '@/utils/fn';
 
 import { ROUTES } from './routes';
 
@@ -29,21 +30,21 @@ export const useRedirectWithSession = () => {
   useEffect(() => {
     if (!orgId) return;
     if (!isOrgWelcomed) {
-      router.replace(ROUTES.WELCOME.PATH);
+      depFn(router.replace, ROUTES.WELCOME.PATH);
       return;
     }
     if (!isOneCodeProviderIntegrated || !anyTeamEverExisted) {
-      router.replace(ROUTES.INTEGRATIONS.PATH);
+      depFn(router.replace, ROUTES.INTEGRATIONS.PATH);
       return;
     }
-    router.replace(defaultRoute.PATH);
+    depFn(router.replace, defaultRoute.PATH);
   }, [
     anyTeamEverExisted,
     defaultRoute.PATH,
     isOneCodeProviderIntegrated,
     isOrgWelcomed,
     orgId,
-    router
+    router.replace
   ]);
 };
 


### PR DESCRIPTION
## Change-log

- removes the usage of `useRedirectWithSession()` from teams page
- adds check on the gh-integration and redirects if empty
- handle loading state for the session API