### PR TITLE
Update CI workflows to run pytests and black only for changes in the backend directory #224

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,6 +3,9 @@ name: Black Integration
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - 'backend/**'
+      - '**/*.py'
 
 permissions:
   contents: read

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,8 +3,14 @@ name: Unit Tests
 on:
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'backend/**'
+      - '**/*.py'
   push:
     branches: [ "main" ]
+    paths:
+      - 'backend/**'
+      - '**/*.py'
 
 jobs:
   build:


### PR DESCRIPTION
[<!--  close 224-->](https://github.com/middlewarehq/middleware/issues/224)
Closes #224

This PR addresses issue #224 by updating the GitHub Actions workflows to trigger the Python-centric tests (pytests and black) only when there are changes in the 'backend' directory. Previously, these workflows were running for all pull requests, which could be unnecessary for changes that don't affect the Python code (like updates to the web-server). 

This optimization reduces unnecessary CI runs, speeding up development and reducing resource usage. Changes include:
- Modified `.github/workflows/pytest.yml` to add path filters.
- Adjusted `.github/workflows/black.yml` similarly.

This should streamline the development process for contributors focusing on the TypeScript/Next.js portions of the project by not running Python-specific checks on unrelated PRs.
