### PR TITLE
load env from parent directory

### DIFF
--- a/backend/analytics_server/env.py
+++ b/backend/analytics_server/env.py
@@ -7,4 +7,4 @@ def load_app_env():
     if getenv("FLASK_ENV") == "production":
         load_dotenv("../.env.prod")
     else:
-        load_dotenv("../.env.local")
+        load_dotenv("../../.env")

--- a/web-server/next.config.js
+++ b/web-server/next.config.js
@@ -2,7 +2,7 @@ const analyzer = require('@next/bundle-analyzer');
 const { loadEnvConfig } = require('@next/env');
 const images = require('next-images');
 
-loadEnvConfig('.');
+loadEnvConfig('../.env');
 
 console.info('BUILD ENV:', process.env.NEXT_PUBLIC_APP_ENVIRONMENT);
 

--- a/web-server/package.json
+++ b/web-server/package.json
@@ -78,7 +78,7 @@
     "prod-tun": "bash -c \"$PROD_TUNNEL\"",
     "stage-tun": "bash -c \"$STAGE_TUNNEL\"",
     "http": "node http-server",
-    "dev": "NEXT_MANUAL_SIG_HANDLE=true next",
+    "dev":"[ -e ../.env ] && set -a && . ../.env; NEXT_MANUAL_SIG_HANDLE=true next -p $PORT",
     "dev-prod": "NEXT_MANUAL_SIG_HANDLE=true yarn env prod && next",
     "build": "./scripts/build.sh",
     "zip": "./scripts/zip.sh",


### PR DESCRIPTION
## Linked Issue(s) 
We would like to have a single `.env` file in the root directory and each service should read variables from there.
- made changes in the webserver to load .env from root directory
- made changes in the backend to load .env from root directory