### PR TITLE
Fix/teams reloading

### DIFF
--- a/web-server/pages/integrations.tsx
+++ b/web-server/pages/integrations.tsx
@@ -65,7 +65,7 @@ const Content = () => {
 
   useEffect(() => {
     if (!orgId) return;
-    if (isGithubIntegrated) {
+    if (isGithubIntegrated && !teamCount) {
       depFn(loading.true);
       dispatch(
         fetchTeams({
@@ -74,7 +74,14 @@ const Content = () => {
         })
       ).finally(loading.false);
     }
-  }, [dispatch, isGithubIntegrated, loading.false, loading.true, orgId]);
+  }, [
+    dispatch,
+    isGithubIntegrated,
+    loading.false,
+    loading.true,
+    orgId,
+    teamCount
+  ]);
 
   return (
     <FlexBox col gap2>

--- a/web-server/pages/teams/index.tsx
+++ b/web-server/pages/teams/index.tsx
@@ -29,13 +29,14 @@ function Page() {
       depFn(router.replace, ROUTES.INTEGRATIONS.PATH);
       return;
     }
-    dispatch(
-      fetchTeams({
-        org_id: orgId,
-        provider: Integration.GITHUB
-      })
-    );
-  }, [dispatch, isGithubIntegrated, orgId, router.replace]);
+    if (!teamsList.length)
+      dispatch(
+        fetchTeams({
+          org_id: orgId,
+          provider: Integration.GITHUB
+        })
+      );
+  }, [dispatch, isGithubIntegrated, orgId, router.replace, teamsList.length]);
 
   return (
     <PageWrapper

--- a/web-server/src/components/TeamSelector/TeamSelector.tsx
+++ b/web-server/src/components/TeamSelector/TeamSelector.tsx
@@ -6,7 +6,6 @@ import {
   TerminalOutlined
 } from '@mui/icons-material';
 import { Box } from '@mui/material';
-import { useRouter } from 'next/router';
 import { FC, useRef } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
@@ -56,7 +55,6 @@ export const TeamSelector: FC<{
 
   const { team } = useSingleTeamConfig();
 
-  const router = useRouter();
   const hideTeamMemberFilter = true;
 
   if (!org) return null;

--- a/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
+++ b/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
@@ -100,7 +100,7 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
     [isAppSliceUpdated, dispatch, singleTeamId]
   );
 
-  const [payload, { fetch: fetchTeams, loading: loadingTeams, fetch_state }] =
+  const [payload, { fetch: fetchTeams, loading: loadingTeams }] =
     useAxios<FetchTeamsResponse>(`/resources/orgs/${orgId}/teams`, {
       manual: true,
       onSuccess: updateUsers
@@ -110,8 +110,6 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
     () => payload?.teams || ([] as Team[]),
     [payload?.teams]
   );
-
-  const usersMap = {};
 
   useEffect(() => {
     if (!orgId) return;
@@ -141,7 +139,7 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
     () => ({
       teams,
       apiTeams,
-      usersMap,
+      usersMap: {},
       dateRangeLabel,
       teamsLabel,
       hideDateSelector,
@@ -166,8 +164,7 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
       setRange,
       showAllTeams,
       teams,
-      teamsLabel,
-      usersMap
+      teamsLabel
     ]
   );
 };

--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -182,10 +182,13 @@ export const TeamsCRUDProvider: React.FC<{
       depFn(isSaveLoading.true);
       const repoPayload = repoToPayload(selections.value);
 
+      const capitalizedTeamName =
+        teamName.value.charAt(0).toUpperCase() + teamName.value.slice(1);
+
       return dispatch(
         createTeam({
           org_id: orgId,
-          team_name: teamName.value,
+          team_name: capitalizedTeamName,
           org_repos: repoPayload,
           provider: Integration.GITHUB
         })


### PR DESCRIPTION
## Linked Issue(s) 

Fixes #242 

## Change log

- Adds condition to fetch teams only when teams are empty
- Auto-capitalizes team name on creation, but not on editing
- removes redundant variables from hook