### PR TITLE
Update useLogs.tsx to include cron/cron as log source

### DIFF
--- a/cli/source/hooks/useLogs.tsx
+++ b/cli/source/hooks/useLogs.tsx
@@ -35,7 +35,7 @@ export const useLogs = (
       case LogSource.Postgres:
         return ['postgres/postgres', 'pgs', '#ff70a6'];
       case LogSource.Cron:
-        return ['cron', 'cro', '#ffd166'];
+        return ['cron/cron', 'cro', '#ffd166'];
       default:
         return def;
     }


### PR DESCRIPTION
Closes #274

This pull request updates the useLogs.tsx file to include "cron/cron" as a log source. Previously, only "cron" was included. This change ensures that the correct log source is used when fetching logs.
