### PR TITLE
Update integrationsLinkedAtMap in org API response

### DIFF
--- a/web-server/libdefs/ambient.d.ts
+++ b/web-server/libdefs/ambient.d.ts
@@ -16,6 +16,7 @@ declare type Org = {
   domain: string;
   onboarding_state: string[];
   integrations: Partial<IntegrationsMap>;
+  integrationsLinkedAtMap: Partial<IntegrationsLinkedAtMap>;
 };
 
 declare type ONBOARDING_STEP =
@@ -43,7 +44,10 @@ declare type IdentityMap = Record<
 >;
 
 declare type IntegrationsMap = Record<'github' | 'gitlab' | 'bitbucket', true>;
-
+declare type IntegrationsLinkedAtMap = Record<
+  'github' | 'gitlab' | 'bitbucket',
+  DateString
+>;
 declare type User = {
   id: string;
   created_at: Date;

--- a/web-server/src/contexts/ThirdPartyAuthContext.tsx
+++ b/web-server/src/contexts/ThirdPartyAuthContext.tsx
@@ -18,6 +18,7 @@ export interface AuthContextValue extends AuthState {
   orgId: string | null;
   role: UserRole;
   integrations: User['integrations'];
+  integrationsLinkedAtMap: Org['integrationsLinkedAtMap'];
   onboardingState: OnboardingStep[];
   integrationSet: Set<IntegrationGroup>;
 }
@@ -27,6 +28,7 @@ export const AuthContext = createContext<AuthContextValue>({
   orgId: null,
   role: UserRole.MOM,
   integrations: {},
+  integrationsLinkedAtMap: {},
   onboardingState: [],
   integrationSet: new Set()
 });
@@ -70,11 +72,6 @@ export const AuthProvider: FC = (props) => {
       if (!isMounted()) return;
       const org = session?.org;
       if (org) {
-        // @ts-ignore
-        // window.FreshworksWidget?.('identify', 'ticketForm', {
-        //   name: identifyConfig.name,
-        //   email: identifyConfig.email
-        // });
         dispatch(
           authSlice.actions.init({
             isAuthenticated: true,
@@ -116,8 +113,9 @@ export const AuthProvider: FC = (props) => {
         orgId: state.org?.id,
         role,
         integrations,
+        integrationsLinkedAtMap: state.org?.integrationsLinkedAtMap || {},
         integrationSet,
-        onboardingState: state.org?.onboarding_state || []
+        onboardingState: (state.org?.onboarding_state as OnboardingStep[]) || []
       }}
     >
       {children}


### PR DESCRIPTION
This pull request updates the `integrationsLinkedAtMap` property in the org API response to include the creation date of each integration. This information is useful for tracking when integrations were linked to the organization.