### PR TITLE
Allow search on repo-name as well as org-name

### DIFF
--- a/web-server/pages/api/internal/[org_id]/git_provider_org.ts
+++ b/web-server/pages/api/internal/[org_id]/git_provider_org.ts
@@ -8,6 +8,7 @@ import { Errors, ResponseError } from '@/constants/error';
 import { Integration } from '@/constants/integrations';
 import { LoadedOrg } from '@/types/github';
 import { getBaseRepoFromUnionRepo } from '@/utils/code';
+import { homogenize } from '@/utils/datatype';
 
 export type CodeSourceProvidersIntegration =
   | Integration.GITHUB
@@ -32,8 +33,9 @@ endpoint.handle.GET(getSchema, async (req, res) => {
   ).then((rs) =>
     rs.map(getBaseRepoFromUnionRepo).filter((repo) => {
       if (!search_text) return true;
-      const repoName = `${repo.parent}/${repo.name}`.toLowerCase();
-      const searchText = search_text.toLowerCase();
+      homogenize;
+      const repoName = homogenize(`${repo.parent}/${repo.name}`);
+      const searchText = homogenize(search_text);
       return repoName.includes(searchText);
     })
   );

--- a/web-server/pages/api/internal/[org_id]/git_provider_org.ts
+++ b/web-server/pages/api/internal/[org_id]/git_provider_org.ts
@@ -32,7 +32,7 @@ endpoint.handle.GET(getSchema, async (req, res) => {
   ).then((rs) =>
     rs.map(getBaseRepoFromUnionRepo).filter((repo) => {
       if (!search_text) return true;
-      const repoName = repo.name.toLowerCase();
+      const repoName = `${repo.parent}/${repo.name}`.toLowerCase();
       const searchText = search_text.toLowerCase();
       return repoName.includes(searchText);
     })

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -170,7 +170,7 @@ const TeamRepos: FC<{ hideCardComponents?: boolean }> = ({
           options={repoOptions}
           value={selectedRepos}
           onChange={handleRepoSelectionChange}
-          getOptionLabel={(option) => option.name}
+          getOptionLabel={(option) => `${option.parent}/${option.name}`}
           renderInput={(params) => (
             <TextField
               onChange={handleReposSearch}


### PR DESCRIPTION
- This pull request enables searching for repositories using both the repository name and the organization name.
- Previously, only the repository name was searchable. 
- This enhancement improves the search functionality by including the organization name in the search criteria.

https://github.com/middlewarehq/middleware/assets/76566992/c7405d98-c245-4ab7-b7f5-27b385e93b13

