### PR TITLE
Remove useRedirectWithSession hook from integrations page

### DIFF
--- a/web-server/pages/integrations.tsx
+++ b/web-server/pages/integrations.tsx
@@ -8,7 +8,6 @@ import { Line } from '@/components/Text';
 import { Integration } from '@/constants/integrations';
 import { ROUTES } from '@/constants/routes';
 import { FetchState } from '@/constants/ui-states';
-import { useRedirectWithSession } from '@/constants/useRoute';
 import { GithubIntegrationCard } from '@/content/Dashboards/IntegrationCards';
 import { PageWrapper } from '@/content/PullRequests/PageWrapper';
 import { useAuth } from '@/hooks/useAuth';
@@ -21,7 +20,6 @@ import { PageLayout, IntegrationGroup } from '@/types/resources';
 import { depFn } from '@/utils/fn';
 
 function Integrations() {
-  useRedirectWithSession();
   const isLoading = useSelector(
     (s) => s.team.requests?.teams === FetchState.REQUEST
   );


### PR DESCRIPTION
This pull request removes the useRedirectWithSession hook from the integrations page. The hook is no longer needed and can be safely removed.