### PR TITLE
"Fix rendering of creation-cta and limit search results"

### DIFF
--- a/web-server/pages/integrations.tsx
+++ b/web-server/pages/integrations.tsx
@@ -17,7 +17,6 @@ import { appSlice } from '@/slices/app';
 import { fetchTeams } from '@/slices/team';
 import { useDispatch, useSelector } from '@/store';
 import { PageLayout, IntegrationGroup } from '@/types/resources';
-import { depFn } from '@/utils/fn';
 
 function Integrations() {
   const isLoading = useSelector(
@@ -60,32 +59,26 @@ const Content = () => {
   const hasCodeProviderLinked = integrationSet.has(IntegrationGroup.CODE);
   const teamCount = useSelector((s) => s.team.teams?.length);
   const dispatch = useDispatch();
-  const loading = useBoolState(false);
+  const loadedTeams = useBoolState(false);
 
-  const showCreationCTA = hasCodeProviderLinked && !teamCount && !loading.value;
+  const showCreationCTA =
+    hasCodeProviderLinked && !teamCount && loadedTeams.value;
 
   useEffect(() => {
     if (!orgId) return;
+    if (!isGithubIntegrated) {
+      dispatch(appSlice.actions.setSingleTeam([]));
+      return;
+    }
     if (isGithubIntegrated && !teamCount) {
-      depFn(loading.true);
       dispatch(
         fetchTeams({
           org_id: orgId,
           provider: Integration.GITHUB
         })
-      ).finally(loading.false);
+      ).finally(loadedTeams.true);
     }
-    if (!isGithubIntegrated) {
-      dispatch(appSlice.actions.setSingleTeam([]));
-    }
-  }, [
-    dispatch,
-    isGithubIntegrated,
-    loading.false,
-    loading.true,
-    orgId,
-    teamCount
-  ]);
+  }, [dispatch, isGithubIntegrated, loadedTeams.true, orgId, teamCount]);
 
   return (
     <FlexBox col gap2>

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -49,7 +49,7 @@ const TeamsCRUD: FC<CRUDProps> = ({
   onDiscard,
   hideCardComponents
 }) => {
-  const { isPageLoading } = useTeamCRUD();
+  const { isPageLoading, editingTeam, isEditing } = useTeamCRUD();
   return (
     <>
       {isPageLoading ? (
@@ -63,10 +63,16 @@ const TeamsCRUD: FC<CRUDProps> = ({
           p={2}
           width={'900px'}
         >
-          <Heading />
-          <TeamName />
-          <TeamRepos hideCardComponents={hideCardComponents} />
-          <ActionTray onDiscard={onDiscard} onSave={onSave} />
+          {isEditing && !editingTeam?.name ? (
+            <FlexBox>No team selected</FlexBox>
+          ) : (
+            <>
+              <Heading />
+              <TeamName />
+              <TeamRepos hideCardComponents={hideCardComponents} />
+              <ActionTray onDiscard={onDiscard} onSave={onSave} />
+            </>
+          )}
         </FlexBox>
       )}
     </>
@@ -147,7 +153,7 @@ const TeamRepos: FC<{ hideCardComponents?: boolean }> = ({
     selectedRepos,
     raiseTeamRepoError,
     loadingRepos,
-    handleReposSearch,
+    handleReposSearch
   } = useTeamCRUD();
 
   return (

--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -165,7 +165,7 @@ export const TeamsCRUDProvider: React.FC<{
     if (isEditing) {
       const selectedTeam = editingTeam;
       const selectedTeamRepos =
-        teamReposMaps?.[teamId].map(adaptBaseRepo) || [];
+        teamReposMaps?.[teamId]?.map(adaptBaseRepo) || [];
       return {
         name: selectedTeam?.name || '',
         repos: selectedTeamRepos

--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -82,11 +82,6 @@ export const TeamsCRUDProvider: React.FC<{
   const isPageLoading = useSelector(
     (s) => s.team.requests?.teams === FetchState.REQUEST
   );
-  const {
-    loadingRepos,
-    onChange: handleReposSearch,
-    searchResults: repoSearchResult
-  } = useReposSearch();
 
   const fetchTeamsAndRepos = useCallback(() => {
     return dispatch(
@@ -118,8 +113,21 @@ export const TeamsCRUDProvider: React.FC<{
 
   // team-repo selection logic
   const selections = useEasyState<BaseRepo[]>([]);
-  const selectedRepos = selections.value;
+  const selectedRepos = useMemo(() => selections.value, [selections.value]);
   const teamRepoError = useBoolState();
+  const {
+    loadingRepos,
+    onChange: handleReposSearch,
+    searchResults
+  } = useReposSearch();
+  const repoSearchResult = useMemo(
+    () =>
+      searchResults.filter(
+        (repo) => !selectedRepos.find((r) => r.id === repo.id)
+      ),
+    [searchResults, selectedRepos]
+  );
+
   const raiseTeamRepoError = useCallback(() => {
     if (!selections.value.length) {
       depFn(teamRepoError.true);


### PR DESCRIPTION
This pull request includes the following changes:

- Fixes rendering the creation-cta on first load on /integrations.

- Limits search results to 5 in git_provider_org API.

- Filters already selected repos from search results. https://github.com/middlewarehq/middleware/issues/301

-  fixes the breaking of UI when reloading edit-link on deleted team https://github.com/middlewarehq/middleware/issues/318


The code changes in this pull request address the mentioned issues and improve the functionality of the code.