### PR TITLE
"Fix team-updation API breaking and improve team branch mapping logic"

### DIFF
--- a/web-server/pages/api/internal/team/[team_id]/repo_branches.ts
+++ b/web-server/pages/api/internal/team/[team_id]/repo_branches.ts
@@ -53,7 +53,7 @@ endpoint.handle.PUT(putSchema, async (req, res) => {
   }));
   await handleRequest<Omit<TeamRepoBranchDetails, 'name'>[]>(
     `/teams/${team_id}/team_repos`,
-    { method: 'PUT', data: { team_repos_data: adapted_team_repos_data } }
+    { method: 'PATCH', data: { team_repos_data: adapted_team_repos_data } }
   );
 
   return res.send(team_repos_data);

--- a/web-server/pages/api/resources/orgs/[org_id]/teams/team_branch_map.ts
+++ b/web-server/pages/api/resources/orgs/[org_id]/teams/team_branch_map.ts
@@ -1,0 +1,35 @@
+import * as yup from 'yup';
+
+import {
+  getAllTeamsReposProdBranchesForOrg,
+  transformTeamRepoBranchesToMap
+} from '@/api/internal/team/[team_id]/repo_branches';
+import { Endpoint } from '@/api-helpers/global';
+import { getTeamV2Mock } from '@/mocks/teams';
+
+const getSchema = yup.object().shape({});
+
+const pathnameSchema = yup.object().shape({
+  org_id: yup.string().uuid().required()
+});
+
+const endpoint = new Endpoint(pathnameSchema);
+
+endpoint.handle.GET(getSchema, async (req, res) => {
+  if (req.meta?.features?.use_mock_data) {
+    return res.send(getTeamV2Mock['teamReposProdBranchMap']);
+  }
+
+  const { org_id } = req.payload;
+
+  const teamsReposProductionBranchDetails =
+    await getAllTeamsReposProdBranchesForOrg(org_id);
+
+  const teamReposProdBranchMap = transformTeamRepoBranchesToMap(
+    teamsReposProductionBranchDetails
+  );
+
+  res.send({ teamReposProdBranchMap });
+});
+
+export default endpoint.serve();

--- a/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
+++ b/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
@@ -1,23 +1,16 @@
-import { AxiosResponse } from 'axios';
 import { format } from 'date-fns';
 import pluralize, { plural } from 'pluralize';
-import { prop } from 'ramda';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { track } from '@/constants/events';
+import { Integration } from '@/constants/integrations';
+import { FetchState } from '@/constants/ui-states';
 import { useAuth } from '@/hooks/useAuth';
-import { useAxios } from '@/hooks/useAxios';
 import { useStateTeamConfig } from '@/hooks/useStateTeamConfig';
-import { appSlice } from '@/slices/app';
-import { teamSlice } from '@/slices/team';
+import { appSlice, updateTeamBranchesMap } from '@/slices/app';
+import { fetchTeams } from '@/slices/team';
 import { useSelector } from '@/store';
-import { Team } from '@/types/api/teams';
-import {
-  ActiveBranchMode,
-  FetchTeamsResponse,
-  TeamSelectorModes
-} from '@/types/resources';
+import { ActiveBranchMode, TeamSelectorModes } from '@/types/resources';
 
 type UseTeamSelectorSetupArgs = { mode: TeamSelectorModes };
 /**
@@ -27,7 +20,7 @@ type UseTeamSelectorSetupArgs = { mode: TeamSelectorModes };
  */
 export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
   const dispatch = useDispatch();
-  const { dateRange, singleTeam, singleTeamId, setRange, partiallyUnselected } =
+  const { dateRange, singleTeam, setRange, partiallyUnselected } =
     useStateTeamConfig();
   const {
     orgId,
@@ -40,11 +33,9 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
   const teams = singleTeam;
   const hideDateSelector = mode === 'single-only' || mode === 'multiple-only';
   const hideTeamSelector = mode === 'date-only';
-  const teamIds = teams.map(prop('id')).join(',');
   const teamReposProdBranchMap = useSelector(
     (state) => state.app.teamsProdBranchMap
   );
-  const isAppSliceUpdated = useSelector((state) => state.app.isUpdated);
 
   const setProdBranchNamesByTeamId = useCallback(
     (teamId: ID) => {
@@ -63,61 +54,23 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
     [dispatch, isAllBranchMode, teamReposProdBranchMap]
   );
 
-  const updateTeams = useCallback(
-    (res: AxiosResponse<FetchTeamsResponse>) => {
-      dispatch(teamSlice.actions.setTeams(res.data.teams));
-      dispatch(teamSlice.actions.setTeamReposMaps(res.data.teamReposMap));
-      dispatch(
-        appSlice.actions.setTeamProdBranchMap(res.data.teamReposProdBranchMap)
-      );
-      const teams = res.data.teams.filter((t) => t.id);
+  const fetchAllTeams = useCallback(async () => {
+    await Promise.all([
+      dispatch(fetchTeams({ org_id: orgId, provider: Integration.GITHUB })),
+      dispatch(updateTeamBranchesMap({ orgId }))
+    ]);
+  }, [dispatch, orgId]);
 
-      const singleT = teams.find((team) => singleTeamId === team.id);
-      const biggestT = biggestTeam(teams);
-      const teamProdBranchNames =
-        res.data.teamReposProdBranchMap?.[singleT?.id]
-          ?.map((r) => r.prod_branches)
-          .filter(Boolean)
-          .join(',') || '';
-
-      if (singleT) {
-        dispatch(appSlice.actions.setSingleTeam([singleT]));
-        if (!isAppSliceUpdated) {
-          dispatch(
-            appSlice.actions.setBranchState({
-              mode: ActiveBranchMode.PROD,
-              names: teamProdBranchNames
-            })
-          );
-        }
-      } else
-        dispatch(appSlice.actions.setSingleTeam(biggestT ? [biggestT] : []));
-
-      track('APP_TEAM_CHANGE_AUTO', { singleT });
-    },
-    [isAppSliceUpdated, dispatch, singleTeamId]
-  );
-
-  const [payload, { fetch: fetchTeams, loading: loadingTeams }] =
-    useAxios<FetchTeamsResponse>(`/resources/orgs/${orgId}/teams`, {
-      manual: true,
-      onSuccess: updateTeams
-    });
-
-  const apiTeams = useMemo(
-    () => payload?.teams || ([] as Team[]),
-    [payload?.teams]
+  const apiTeams = useSelector((state) => state.team.teams);
+  const loadingTeams = useSelector(
+    (state) => state.team.requests?.teams === FetchState.REQUEST
   );
 
   useEffect(() => {
     if (!orgId) return;
 
-    const params: any = {};
-    const ids = teamIds.split(',').filter(Boolean);
-    if (ids.length) params.include_teams = ids;
-
-    if (isGithubIntegrations) fetchTeams({ params });
-  }, [fetchTeams, isGithubIntegrations, orgId, teamIds]);
+    if (isGithubIntegrations) fetchAllTeams();
+  }, [fetchAllTeams, isGithubIntegrations, orgId]);
 
   const dateRangeLabel = !partiallyUnselected
     ? `${format(dateRange[0], 'do MMM')} to ${format(dateRange[1], 'do MMM')}`
@@ -126,10 +79,10 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
     ? !isSingleMode
       ? `${teams.length} ${pluralize('team', teams.length)} selected`
       : `${teams[0]?.name} (${
-          teamReposProdBranchMap[teams[0]?.id]?.length || 0
+          teamReposProdBranchMap?.[teams[0]?.id]?.length || 0
         } ${pluralize(
           'repo',
-          teamReposProdBranchMap[teams[0]?.id]?.length || 0
+          teamReposProdBranchMap?.[teams[0]?.id]?.length || 0
         )})`
     : `Select ${!isSingleMode ? plural('Team') : 'Team'}`;
   return useMemo(
@@ -164,19 +117,4 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
       teamsLabel
     ]
   );
-};
-
-const biggestTeam = (argTeams: Team[]) => {
-  if (!argTeams.length) return null;
-
-  let teams = argTeams;
-
-  let biggest = teams[0];
-
-  teams.forEach((team) => {
-    if (team.member_ids.length <= biggest.member_ids.length) return;
-    biggest = team;
-  });
-
-  return biggest;
 };

--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -14,6 +14,7 @@ import { Integration } from '@/constants/integrations';
 import { FetchState } from '@/constants/ui-states';
 import { useAuth } from '@/hooks/useAuth';
 import { useBoolState, useEasyState } from '@/hooks/useEasyState';
+import { updateTeamBranchesMap } from '@/slices/app';
 import {
   fetchTeams,
   createTeam,
@@ -264,6 +265,7 @@ export const TeamsCRUDProvider: React.FC<{
             autoHideDuration: 2000
           });
           fetchTeamsAndRepos();
+          dispatch(updateTeamBranchesMap({ orgId }));
           callBack?.(res);
         })
         .finally(isSaveLoading.false);

--- a/web-server/src/slices/dora_metrics.ts
+++ b/web-server/src/slices/dora_metrics.ts
@@ -155,7 +155,8 @@ export const fetchTeamDoraMetrics = createAsyncThunk(
         params: {
           org_id: params.orgId,
           from_date: params.fromDate,
-          to_date: params.toDate
+          to_date: params.toDate,
+          branches: params.branches
         }
       }
     );


### PR DESCRIPTION
## Linked Issues
https://github.com/middlewarehq/middleware/issues/320
https://github.com/middlewarehq/middleware/issues/319
https://github.com/middlewarehq/middleware/issues/256
https://github.com/middlewarehq/middleware/issues/258

This pull request includes several commits that fix the team-updation API breaking issue and improve the logic for mapping team branches. The changes include:

- passing branches to the dora-metrics API params,
- creating new API fetching team-prod-branch-map, 
- creating an asyncThunk to populate teambranchmap and branch-details, 
- fetching team-branch map after updating edits, and 
- replacing useAxios logic with dispatch and slice-based logic. 


These changes ensure that the team-updation API works correctly and improve the efficiency of mapping team branches.