### PR TITLE
Fix lead-time to CFR data inconsistency

### DIFF
--- a/web-server/src/slices/dora_metrics.ts
+++ b/web-server/src/slices/dora_metrics.ts
@@ -108,7 +108,8 @@ export const doraMetricsSlice = createSlice({
       (state, action) => {
         state.all_deployments = action.payload.deployments_with_incidents;
         state.revert_prs = action.payload.revert_prs;
-        state.summary_prs = action.payload.summary_prs;
+        // TODO: Impement when summary PRs are available
+        // state.summary_prs = action.payload.summary_prs;
       }
     );
     addFetchCasesToReducer(


### PR DESCRIPTION
#329 

This pull request fixes the lead-time to CFR data inconsistency issue. 

since we are sending empty summary PRs in `get_incidents`, it removes this data, causing empty leadtime on implementing the API for get_incidents, we can re-integrate the commented code