### PR TITLE
fix 'cannot take exclusive lock for project' error

### DIFF
--- a/cli/source/constants.ts
+++ b/cli/source/constants.ts
@@ -27,7 +27,8 @@ export enum LogSource {
   InitDb,
   Postgres,
   Cron,
-  DockerWatch
+  DockerWatch,
+  DockerWatchProcessIdLock
 }
 
 export type LogEntry = {
@@ -65,5 +66,8 @@ export const READY_MESSAGES = {
     `Watch enabled`,
     `watch enabled`,
     `watching`
+  ],
+  [LogSource.DockerWatchProcessIdLock]: [
+    `cannot take exclusive lock for project`
   ]
 };

--- a/cli/source/utils/circularBuffer.ts
+++ b/cli/source/utils/circularBuffer.ts
@@ -1,0 +1,50 @@
+class CircularBuffer<T> {
+  private buffer: T[];
+  private head: number;
+  private tail: number;
+  private size: number;
+  private capacity: number;
+
+  constructor(capacity: number) {
+    this.buffer = new Array<T>(capacity);
+    this.head = 0;
+    this.tail = 0;
+    this.size = 0;
+    this.capacity = capacity;
+  }
+
+  enqueue(item: T): void {
+    if (this.size === this.capacity) {
+      this.dequeue();
+    }
+    this.buffer[this.tail] = item;
+    this.tail = (this.tail + 1) % this.capacity;
+    this.size++;
+  }
+
+  dequeue(): T | undefined {
+    if (this.size === 0) {
+      return undefined;
+    }
+    const item = this.buffer[this.head];
+    this.head = (this.head + 1) % this.capacity;
+    this.size--;
+    return item;
+  }
+
+  get length(): number {
+    return this.size;
+  }
+
+  get items(): T[] {
+    const items: T[] = [];
+    let index = this.head;
+    for (let i = 0; i < this.size; i++) {
+      items.push(this.buffer[index]!);
+      index = (index + 1) % this.capacity;
+    }
+    return items;
+  }
+}
+
+export default CircularBuffer;


### PR DESCRIPTION
The CLI had an issue where it would throw error `cannot take exclusive lock for project "dora-metrics": process with PID 113930 is still running`. This was caused by another instance of docker-watch running or not exiting properly. So the solution was to parse the log and look for this error. Then from that extract the `PID` of the process and run the kill command. Now when we run the kill command we toggle the retry useState flag so that the useEffect starts again thereby starting docker-watch again.

Now the other problem was that the error was getting caught due to process.on('close'.......) which in turn resulted in the execution of the handleExit() function. To avoid this, a circular buffer was created to store the last 10 logs, and when the 'close' event is triggered we search for the specific error and if found, we simply resolve the promise.

