### PR TITLE
Add tooltip for long repository names in CreateTeams component

### DIFF
--- a/web-server/http-server.js
+++ b/web-server/http-server.js
@@ -34,7 +34,7 @@ const MAX_ERR_GAP = 10;
 let gapThreshold = clamp(0, MAX_ERR_GAP, Number(read('gap-threshold') || 0));
 
 const channel = {
-  webServerAlerts: `https://hooks.slack.com/services/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`,
+  webServerAlerts: ``,
   botTest: ``
 };
 

--- a/web-server/http-server.js
+++ b/web-server/http-server.js
@@ -35,7 +35,7 @@ let gapThreshold = clamp(0, MAX_ERR_GAP, Number(read('gap-threshold') || 0));
 
 const channel = {
   webServerAlerts: `https://hooks.slack.com/services/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`,
-  botTest: `https://hooks.slack.com/services/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`
+  botTest: ``
 };
 
 app

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -5,7 +5,8 @@ import {
   Card,
   CircularProgress,
   Divider,
-  TextField
+  TextField,
+  Tooltip
 } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { FC } from 'react';
@@ -26,6 +27,8 @@ export type CRUDProps = {
   teamId?: ID;
   hideCardComponents?: boolean;
 };
+
+const MAX_LENGTH_REPO_NAME = 25;
 
 export const CreateEditTeams: FC<CRUDProps> = ({
   onSave,
@@ -223,10 +226,20 @@ const TeamRepos: FC<{ hideCardComponents?: boolean }> = ({
                   overflow: 'hidden'
                 }}
               >
-                <Line sx={{ maxWidth: '200px', overflow: 'hidden' }}>
-                  {option.parent ? option.parent + '/' : ''}
-                  {option.name}
-                </Line>
+                <FlexBox col sx={{ maxWidth: '200px', overflow: 'hidden' }}>
+                  {option.parent && <Line tiny>{option.parent}</Line>}
+
+                  {option.name.length > MAX_LENGTH_REPO_NAME ? (
+                    <Tooltip title={option.name}>
+                      <Line>{`${option.name.substring(
+                        0,
+                        MAX_LENGTH_REPO_NAME
+                      )}...`}</Line>
+                    </Tooltip>
+                  ) : (
+                    <Line>{option.name}</Line>
+                  )}
+                </FlexBox>
                 {selected ? <Close fontSize="small" /> : null}
               </FlexBox>
             </li>


### PR DESCRIPTION
This pull request adds a tooltip feature to the CreateTeams component in order to display the full name of repositories when they exceed a maximum length of 25 characters. The tooltip provides a more user-friendly experience by allowing users to hover over truncated repository names and view the complete name. This enhancement improves the readability and usability of the CreateTeams component.