### PR TITLE
Shorten team names on Teams page and refresh Dora page data

### DIFF
--- a/web-server/pages/teams/index.tsx
+++ b/web-server/pages/teams/index.tsx
@@ -22,7 +22,7 @@ function Page() {
     integrations: { github: isGithubIntegrated }
   } = useAuth();
   const teamsList = useSelector((state) => state.team.teams);
-  const loading = useBoolState(true);
+  const loading = useBoolState(!Boolean(teamsList.length));
 
   const fetchAllTeams = useCallback(async () => {
     depFn(loading.true);

--- a/web-server/src/components/OverlayComponents/TeamEdit.tsx
+++ b/web-server/src/components/OverlayComponents/TeamEdit.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 
 import { CRUDProps } from '@/components/Teams/CreateTeams';
+import { usePageRefreshCallback } from '@/hooks/usePageRefreshCallback';
 
 import { FlexBox } from '../FlexBox';
 import { useOverlayPage } from '../OverlayPageContext';
@@ -8,13 +9,18 @@ import { CreateEditTeams } from '../Teams/CreateTeams';
 
 export const TeamEdit: FC<CRUDProps> = ({ teamId, hideCardComponents }) => {
   const { removeAll } = useOverlayPage();
+  const pageRefreshCallback = usePageRefreshCallback();
+
   return (
     <FlexBox>
       <CreateEditTeams
         teamId={teamId}
         hideCardComponents={hideCardComponents}
         onDiscard={removeAll}
-        onSave={removeAll}
+        onSave={() => {
+          removeAll();
+          pageRefreshCallback();
+        }}
       />
     </FlexBox>
   );

--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -11,6 +11,7 @@ import { useSnackbar } from 'notistack';
 import pluralize from 'pluralize';
 import { ascend } from 'ramda';
 import { FC, MouseEventHandler, useCallback, useMemo } from 'react';
+import { truncate } from 'voca';
 
 import { Integration } from '@/constants/integrations';
 import { ROUTES } from '@/constants/routes';
@@ -179,11 +180,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit }) => {
   );
 
   const minifiedName = useMemo(() => {
-    if (teamName.length <= 25) {
-      return teamName;
-    }
-    const miniName = teamName.slice(0, 25);
-    return miniName + '...';
+    return truncate(teamName, 25);
   }, [teamName]);
 
   return (

--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -54,8 +54,7 @@ export const TeamsList = () => {
   }, [showCreate.toggle]);
 
   const isLoadingTeams = useSelector(
-    (state) =>
-      state.team?.requests?.teams === FetchState.REQUEST
+    (state) => state.team?.requests?.teams === FetchState.REQUEST
   );
 
   return (
@@ -179,14 +178,27 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit }) => {
     [assignedReposToTeam]
   );
 
+  const minifiedName = useMemo(() => {
+    if (teamName.length <= 25) {
+      return teamName;
+    }
+    const miniName = teamName.slice(0, 25);
+    return miniName + '...';
+  }, [teamName]);
+
   return (
     <FlexBox component={Card} p={2} minHeight={'144px'} gap2>
       <FlexBox fullWidth col gap2 justifyBetween>
         <FlexBox col gap2>
           <FlexBox justifyBetween alignStart>
-            <Line big semibold>
-              {teamName}
-            </Line>
+            <FlexBox
+              title={minifiedName === teamName ? null : teamName}
+              tooltipPlacement="right"
+            >
+              <Line big semibold>
+                {minifiedName}
+              </Line>
+            </FlexBox>
           </FlexBox>
 
           <FlexBox gap2 alignCenter minHeight={'64px'}>

--- a/web-server/src/content/DoraMetrics/Incidents.tsx
+++ b/web-server/src/content/DoraMetrics/Incidents.tsx
@@ -116,7 +116,7 @@ export const AllIncidentsBody = () => {
   const { trendsSeriesMap } = useDoraMetricsGraph();
   const isTrendSeriesAvailable = head(
     trendsSeriesMap?.changeFailureRateTrends || []
-  )?.data?.some((s) => s.y);
+  )?.data?.some((s) => s?.y);
 
   if (isLoading) return <MiniLoader label="Fetching incidents ..." />;
   if (!allDeployments.length || !isTrendSeriesAvailable)

--- a/web-server/src/content/DoraMetrics/Incidents.tsx
+++ b/web-server/src/content/DoraMetrics/Incidents.tsx
@@ -116,7 +116,7 @@ export const AllIncidentsBody = () => {
   const { trendsSeriesMap } = useDoraMetricsGraph();
   const isTrendSeriesAvailable = head(
     trendsSeriesMap?.changeFailureRateTrends || []
-  )?.data?.length;
+  )?.data?.some((s) => s.y);
 
   if (isLoading) return <MiniLoader label="Fetching incidents ..." />;
   if (!allDeployments.length || !isTrendSeriesAvailable)


### PR DESCRIPTION
## Linked Issues
#349 
#334 
#337

## Change-log
- snips very long team-names on the `/teams` page
- refreshes data for the dora-page when teams are edited/updated
- fixes empty CFR modal