### PR TITLE
Add GraphQL API to fetch user and org-repos

### DIFF
--- a/web-server/pages/api/internal/[org_id]/git_provider_org.ts
+++ b/web-server/pages/api/internal/[org_id]/git_provider_org.ts
@@ -1,15 +1,9 @@
-import { AxiosError } from 'axios';
 import * as yup from 'yup';
 
-import { internal } from '@/api-helpers/axios';
+import { searchGithubRepos } from '@/api/internal/[org_id]/utils';
 import { Endpoint } from '@/api-helpers/global';
-import { Errors, ResponseError } from '@/constants/error';
 import { Integration } from '@/constants/integrations';
-import { LoadedOrg, Repo } from '@/types/github';
-import { BaseRepo } from '@/types/resources';
 import { dec } from '@/utils/auth-supplementary';
-import { getBaseRepoFromUnionRepo } from '@/utils/code';
-import { homogenize } from '@/utils/datatype';
 import { db, getFirstRow } from '@/utils/db';
 
 export type CodeSourceProvidersIntegration =
@@ -30,57 +24,17 @@ const endpoint = new Endpoint(pathSchema);
 
 endpoint.handle.GET(getSchema, async (req, res) => {
   const { org_id, search_text } = req.payload;
-  let count = 0;
-  const repos = await getRepos(org_id, search_text);
 
-  const searchResults = [] as BaseRepo[];
-  for (let raw_repo of repos) {
-    const repo = getBaseRepoFromUnionRepo(raw_repo);
-    if (count >= 5) break;
-    if (!search_text) {
-      count++;
-      searchResults.push(repo);
-      continue;
-    }
-    const repoName = homogenize(`${repo.parent}/${repo.name}`);
-    const searchText = homogenize(search_text);
-    const matchesSearch = repoName.includes(searchText);
-    if (matchesSearch) {
-      count++;
-      searchResults.push(repo);
-    }
-  }
-  return res.status(200).send(searchResults);
+  const token = await getGithubToken(org_id);
+  const repos = await searchGithubRepos(token, search_text);
+
+  return res.status(200).send(repos);
 });
 
 export default endpoint.serve();
 
-const providerOrgBrandingMap = {
-  bitbucket: 'workspaces',
-  github: 'orgs',
-  gitlab: 'groups'
-};
-
-const THRESHOLD = 300;
-
-export const getProviderOrgs = (
-  org_id: ID,
-  provider: CodeSourceProvidersIntegration
-) =>
-  internal
-    .get<{ orgs: LoadedOrg[] }>(
-      `/orgs/${org_id}/integrations/${provider}/${providerOrgBrandingMap[provider]}`
-    )
-    .catch((e: AxiosError) => {
-      if (e.response.status !== 404) throw e;
-      throw new ResponseError(Errors.INTEGRATION_NOT_FOUND);
-    });
-
-async function getRepos(
-  org_id: ID,
-  searchQuery?: string
-): Promise<Partial<Repo>[]> {
-  const token = await db('Integration')
+const getGithubToken = async (org_id: ID) => {
+  return await db('Integration')
     .select()
     .where({
       org_id,
@@ -89,46 +43,4 @@ async function getRepos(
     .returning('*')
     .then(getFirstRow)
     .then((r) => dec(r.access_token_enc_chunks));
-
-  const baseUrl = 'https://api.github.com/user/repos';
-  const params: URLSearchParams = new URLSearchParams();
-  params.set('access_token', token);
-
-  if (searchQuery) {
-    params.set('q', searchQuery);
-  }
-
-  let allRepos: any[] = [];
-  let url = `${baseUrl}?${params.toString()}`;
-  let response: Response;
-
-  do {
-    if (allRepos.length >= THRESHOLD) {
-      break;
-    }
-    response = await fetch(url, {
-      headers: {
-        Authorization: `token ${token}`
-      }
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch repos: ${response.statusText}`);
-    }
-
-    const data = (await response.json()) as any[];
-    allRepos = allRepos.concat(data);
-
-    const nextLink = response.headers.get('Link');
-    if (nextLink) {
-      const nextUrl = nextLink
-        .split(',')
-        .find((link) => link.includes('rel="next"'));
-      url = nextUrl ? nextUrl.trim().split(';')[0].slice(1, -1) : '';
-    } else {
-      url = '';
-    }
-  } while (url);
-
-  return allRepos;
-}
+};

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -1,0 +1,177 @@
+import { BaseRepo } from '@/types/resources';
+
+const GITHUB_API_URL = 'https://api.github.com/graphql';
+
+interface Repo {
+  id: string;
+  name: string;
+  url: string;
+  isPrivate: boolean;
+  owner: string;
+}
+
+async function getOrgs(pat: string): Promise<string[]> {
+  const query = `
+        query {
+            viewer {
+                organizations(first: 100) {
+                    nodes {
+                        login
+                    }
+                }
+            }
+        }
+    `;
+
+  const response = await fetch(GITHUB_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${pat}`
+    },
+    body: JSON.stringify({ query })
+  });
+
+  const responseBody = (await response.json()) as any;
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${responseBody.message}`);
+  }
+
+  return responseBody.data.viewer.organizations.nodes.map(
+    (org: any) => org.login
+  );
+}
+
+async function getUserRepos(
+  pat: string,
+  searchString: string
+): Promise<Repo[]> {
+  const query = `
+        query($queryString: String!) {
+            search(type: REPOSITORY, query: $queryString, first: 50) {
+                edges {
+                    node {
+                        ... on Repository {
+                            name
+                            url
+                            databaseId
+                            description
+                            owner {
+                                login
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+  const queryString = `${searchString} in:name user:@me`;
+
+  const response = await fetch(GITHUB_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${pat}`
+    },
+    body: JSON.stringify({ query, variables: { queryString } })
+  });
+
+  const responseBody = (await response.json()) as any;
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${responseBody.message}`);
+  }
+
+  const repositories = responseBody.data.search.edges.map(
+    (edge: any) => edge.node
+  );
+
+  return repositories.map(
+    (repo: any) =>
+      ({
+        id: repo.databaseId,
+        name: repo.name,
+        desc: repo.description,
+        slug: repo.name,
+        parent: repo.owner.login,
+        web_url: repo.url,
+        language: repo.languages,
+        branch: ''
+      }) as BaseRepo
+  );
+}
+
+async function searchGithubRepos(
+  pat: string,
+  searchString: string
+): Promise<Repo[]> {
+  const organizations = await getOrgs(pat);
+
+  const repoPromises = organizations.map(async (org) => {
+    const query = `
+            query($queryString: String!) {
+                search(type: REPOSITORY, query: $queryString, first: 50) {
+                    edges {
+                        node {
+                            ... on Repository {
+                                name
+                                url
+                                description
+                                databaseId
+                                owner {
+                                    login
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+    const queryString = `org:${org} ${searchString} in:name`;
+
+    const response = await fetch(GITHUB_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${pat}`
+      },
+      body: JSON.stringify({ query, variables: { queryString } })
+    });
+
+    const responseBody = (await response.json()) as any;
+
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${responseBody.message}`);
+    }
+
+    const repositories = responseBody.data.search.edges.map(
+      (edge: any) => edge.node
+    );
+
+    return repositories.map(
+      (repo: any) =>
+        ({
+          id: repo.databaseId,
+          name: repo.name,
+          desc: repo.description,
+          slug: repo.name,
+          parent: repo.owner.login,
+          web_url: repo.url,
+          language: repo.languages,
+          branch: ''
+        }) as BaseRepo
+    );
+  });
+
+  const [userRepos, orgRepos] = await Promise.all([
+    getUserRepos(pat, searchString),
+    await Promise.all(repoPromises)
+  ]);
+
+  return [...userRepos, ...orgRepos.flat()];
+}
+
+export { searchGithubRepos };

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -2,18 +2,37 @@ import { BaseRepo } from '@/types/resources';
 
 const GITHUB_API_URL = 'https://api.github.com/graphql';
 
-interface Repo {
-  id: string;
+type GithubRepo = {
   name: string;
   url: string;
-  isPrivate: boolean;
-  owner: string;
-}
+  defaultBranchRef?: {
+    name: string;
+  };
+  databaseId: string;
+  description?: string;
+  primaryLanguage?: {
+    name: string;
+  };
+  owner: {
+    login: string;
+  };
+};
+
+type RepoReponse = {
+  data: {
+    search: {
+      edges: {
+        node: GithubRepo;
+      }[];
+    };
+  };
+  message?: string;
+};
 
 export const searchGithubRepos = async (
   pat: string,
   searchString: string
-): Promise<Repo[]> => {
+): Promise<BaseRepo[]> => {
   const query = `
           query($queryString: String!) {
               search(type: REPOSITORY, query: $queryString, first: 50) {
@@ -52,18 +71,16 @@ export const searchGithubRepos = async (
     body: JSON.stringify({ query, variables: { queryString } })
   });
 
-  const responseBody = (await response.json()) as any;
+  const responseBody = (await response.json()) as RepoReponse;
 
   if (!response.ok) {
     throw new Error(`GitHub API error: ${responseBody.message}`);
   }
 
-  const repositories = responseBody.data.search.edges.map(
-    (edge: any) => edge.node
-  );
+  const repositories = responseBody.data.search.edges.map((edge) => edge.node);
 
   return repositories.map(
-    (repo: any) =>
+    (repo) =>
       ({
         id: repo.databaseId,
         name: repo.name,

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -68,7 +68,7 @@ export const searchGithubRepos = async (
         id: repo.databaseId,
         name: repo.name,
         desc: repo.description,
-        slug: `${repo.owner.login}/${repo.name}`,
+        slug: repo.name,
         parent: repo.owner.login,
         web_url: repo.url,
         language: repo.primaryLanguage?.name,

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -10,64 +10,38 @@ interface Repo {
   owner: string;
 }
 
-async function getOrgs(pat: string): Promise<string[]> {
-  const query = `
-        query {
-            viewer {
-                organizations(first: 100) {
-                    nodes {
-                        login
-                    }
-                }
-            }
-        }
-    `;
-
-  const response = await fetch(GITHUB_API_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${pat}`
-    },
-    body: JSON.stringify({ query })
-  });
-
-  const responseBody = (await response.json()) as any;
-
-  if (!response.ok) {
-    throw new Error(`GitHub API error: ${responseBody.message}`);
-  }
-
-  return responseBody.data.viewer.organizations.nodes.map(
-    (org: any) => org.login
-  );
-}
-
-async function getUserRepos(
+export const searchGithubRepos = async (
   pat: string,
   searchString: string
-): Promise<Repo[]> {
+): Promise<Repo[]> => {
   const query = `
-        query($queryString: String!) {
-            search(type: REPOSITORY, query: $queryString, first: 50) {
-                edges {
-                    node {
-                        ... on Repository {
-                            name
-                            url
-                            databaseId
-                            description
-                            owner {
-                                login
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    `;
+          query($queryString: String!) {
+              search(type: REPOSITORY, query: $queryString, first: 50) {
+                  edges {
+                      node {
+                          ... on Repository {
+                              name
+                              url
+                              defaultBranchRef {
+                                name
+                              }
+                              databaseId
+                              description
+                              primaryLanguage {
+                                    name
+                                }
+                                
+                              owner {
+                                  login
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      `;
 
-  const queryString = `${searchString} in:name user:@me`;
+  const queryString = `${searchString} in:name`;
 
   const response = await fetch(GITHUB_API_URL, {
     method: 'POST',
@@ -94,84 +68,11 @@ async function getUserRepos(
         id: repo.databaseId,
         name: repo.name,
         desc: repo.description,
-        slug: repo.name,
+        slug: `${repo.owner.login}/${repo.name}`,
         parent: repo.owner.login,
         web_url: repo.url,
-        language: repo.languages,
-        branch: ''
+        language: repo.primaryLanguage?.name,
+        branch: repo.defaultBranchRef?.name
       }) as BaseRepo
   );
-}
-
-async function searchGithubRepos(
-  pat: string,
-  searchString: string
-): Promise<Repo[]> {
-  const organizations = await getOrgs(pat);
-
-  const repoPromises = organizations.map(async (org) => {
-    const query = `
-            query($queryString: String!) {
-                search(type: REPOSITORY, query: $queryString, first: 50) {
-                    edges {
-                        node {
-                            ... on Repository {
-                                name
-                                url
-                                description
-                                databaseId
-                                owner {
-                                    login
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        `;
-
-    const queryString = `org:${org} ${searchString} in:name`;
-
-    const response = await fetch(GITHUB_API_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${pat}`
-      },
-      body: JSON.stringify({ query, variables: { queryString } })
-    });
-
-    const responseBody = (await response.json()) as any;
-
-    if (!response.ok) {
-      throw new Error(`GitHub API error: ${responseBody.message}`);
-    }
-
-    const repositories = responseBody.data.search.edges.map(
-      (edge: any) => edge.node
-    );
-
-    return repositories.map(
-      (repo: any) =>
-        ({
-          id: repo.databaseId,
-          name: repo.name,
-          desc: repo.description,
-          slug: repo.name,
-          parent: repo.owner.login,
-          web_url: repo.url,
-          language: repo.languages,
-          branch: ''
-        }) as BaseRepo
-    );
-  });
-
-  const [userRepos, orgRepos] = await Promise.all([
-    getUserRepos(pat, searchString),
-    await Promise.all(repoPromises)
-  ]);
-
-  return [...userRepos, ...orgRepos.flat()];
-}
-
-export { searchGithubRepos };
+};

--- a/web-server/src/components/DateRangePicker/utils.ts
+++ b/web-server/src/components/DateRangePicker/utils.ts
@@ -187,9 +187,12 @@ export const presetOptions: {
   }
 ];
 
-export const defaultRange =
-  process.env.NEXT_PUBLIC_APP_ENVIRONMENT === 'development'
-    ? DateRangeLogic.oneWeek()
-    : DateRangeLogic.oneMonth();
+export const defaultDate = {
+  preset: 'twoWeeks',
+  range: DateRangeLogic.twoWeeks()
+} as {
+  preset: QuickRangeOptions;
+  range: DateRange;
+};
 
 export const DATE_RANGE_MAX_DIFF = 95;

--- a/web-server/src/slices/app.ts
+++ b/web-server/src/slices/app.ts
@@ -4,8 +4,8 @@ import { head, uniq } from 'ramda';
 
 import { handleApi } from '@/api-helpers/axios-api-instance';
 import {
-  defaultRange,
-  QuickRangeOptions
+  QuickRangeOptions,
+  defaultDate
 } from '@/components/DateRangePicker/utils';
 import { Team } from '@/types/api/teams';
 import { StateFetchConfig } from '@/types/redux';
@@ -72,10 +72,10 @@ const initialState: State = {
   errors: {},
   singleTeam: [],
   allTeams: [],
-  dateRange: defaultRange.map((date) =>
+  dateRange: defaultDate.range.map((date) =>
     date.toISOString()
   ) as SerializableDateRange,
-  dateMode: 'oneMonth',
+  dateMode: defaultDate.preset,
   branchMode: ActiveBranchMode.ALL,
   branchNames: '',
   teamsProdBranchMap: {},


### PR DESCRIPTION
This pull request adds a GraphQL API that allows fetching user and organization repositories based on a Personal Access Token (PAT) and a search string. 
- It simplifies the fetch process by removing org-based logic. 
- The API uses the GitHub GraphQL API to search for repositories matching the given search string. 
- The response includes repository details such as name, URL, owner, and primary language.
- updates default date-range for picker