### PR TITLE
Cancels previous pending request if search-term is changed

### DIFF
--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -1,4 +1,5 @@
 import { debounce } from '@mui/material';
+import axios from 'axios';
 import { useSnackbar } from 'notistack';
 import { equals } from 'ramda';
 import {
@@ -15,13 +16,7 @@ import { FetchState } from '@/constants/ui-states';
 import { useAuth } from '@/hooks/useAuth';
 import { useBoolState, useEasyState } from '@/hooks/useEasyState';
 import { updateTeamBranchesMap } from '@/slices/app';
-import {
-  fetchTeams,
-  createTeam,
-  updateTeam,
-  fetchOrgRepos,
-  teamSlice
-} from '@/slices/team';
+import { fetchTeams, createTeam, updateTeam } from '@/slices/team';
 import { useDispatch, useSelector } from '@/store';
 import { DB_OrgRepo } from '@/types/api/org_repo';
 import { Team } from '@/types/api/teams';
@@ -29,7 +24,6 @@ import { BaseRepo, RepoUniqueDetails } from '@/types/resources';
 import { depFn } from '@/utils/fn';
 
 interface TeamsCRUDContextType {
-  orgRepos: BaseRepo[];
   teams: Team[];
   teamReposMaps: Record<string, DB_OrgRepo[]>;
   teamName: string;
@@ -78,7 +72,6 @@ export const TeamsCRUDProvider: React.FC<{
   const dispatch = useDispatch();
   const teamReposMaps = useSelector((s) => s.team.teamReposMaps);
   const teams = useSelector((s) => s.team.teams);
-  const orgRepos = useSelector((s) => s.team.orgRepos);
   const { orgId } = useAuth();
   const isPageLoading = useSelector(
     (s) => s.team.requests?.teams === FetchState.REQUEST
@@ -301,7 +294,6 @@ export const TeamsCRUDProvider: React.FC<{
   const onDiscard = useCallback(
     (callBack?: AnyFunction) => {
       resetErrors();
-      dispatch(teamSlice.actions.setOrgRepos([]));
       if (!isEditing) {
         depFn(teamName.set, '');
         depFn(selections.set, []);
@@ -313,7 +305,6 @@ export const TeamsCRUDProvider: React.FC<{
     },
     [
       resetErrors,
-      dispatch,
       isEditing,
       teamName.set,
       initState.name,
@@ -348,7 +339,6 @@ export const TeamsCRUDProvider: React.FC<{
     raiseTeamNameError,
     teamReposMaps,
     teams,
-    orgRepos,
     handleTeamNameChange,
     repoOptions: repoSearchResult,
     selectedRepos,
@@ -416,7 +406,7 @@ const useReposSearch = () => {
 
   const debouncedSearch = useCallback(
     debounce((query) => {
-    fetchData(query);
+      fetchData(query);
     }, DEBOUNCE_TIME),
     []
   );
@@ -449,7 +439,7 @@ const useReposSearch = () => {
       }
     },
     [orgId]
-    );
+  );
 
   return {
     searchResults: searchResults.value,

--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -397,10 +397,7 @@ const useReposSearch = () => {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     depFn(isLoading.true);
     const query = e.target.value;
-    if (!query) {
-      depFn(isLoading.false);
-      return;
-    }
+    if (!query) return;
     debouncedSearch(query);
   };
 

--- a/web-server/src/slices/team.ts
+++ b/web-server/src/slices/team.ts
@@ -29,7 +29,6 @@ type State = StateFetchConfig<{
   fetch_error: string;
   teams: Team[];
   showAllTeams?: boolean;
-  orgRepos: BaseRepo[];
   teamRepos: DB_OrgRepo[];
   teamReposProductionBranches: TeamRepoBranchDetails[];
   teamIncidentFilters: null | TeamIncidentSettingsResponse;
@@ -45,7 +44,6 @@ const initialState: State = {
   fetch_error: '',
   teams: [],
   showAllTeams: getUrlParam('show_all') !== 'false',
-  orgRepos: [],
   teamRepos: [],
   teamReposProductionBranches: [],
   teamIncidentFilters: null,
@@ -66,9 +64,6 @@ export const teamSlice = createSlice({
     ): void {
       state.teamReposMaps = action.payload;
     },
-    setOrgRepos(state: State, action: PayloadAction<State['orgRepos']>): void {
-      state.orgRepos = action.payload;
-    },
     setTeamRepos(
       state: State,
       action: PayloadAction<State['teamRepos']>
@@ -87,14 +82,6 @@ export const teamSlice = createSlice({
       state.teams = action.payload.teams;
       state.teamReposMaps = action.payload.teamReposMap;
     });
-    addFetchCasesToReducer(
-      builder,
-      fetchOrgRepos,
-      'orgRepos',
-      (state, action) => {
-        state.orgRepos = action.payload;
-      }
-    );
     addFetchCasesToReducer(
       builder,
       fetchTeamReposProductionBranches,


### PR DESCRIPTION
## Linked Issues
https://github.com/middlewarehq/middleware/issues/303

## Change Log

This pull request refactors the `useReposSearch` function to 
- have only local states and 
- cancels previous pending requests. 

It also completely removes the `orgRepos` state from the `team` slice and other references. 

These changes improve the performance and maintainability of the codebase.