### PR TITLE
Fix time-based tick-values for better readability

### DIFF
--- a/web-server/src/content/DoraMetrics/ResolvedIncidents.tsx
+++ b/web-server/src/content/DoraMetrics/ResolvedIncidents.tsx
@@ -100,7 +100,10 @@ export const ResolvedIncidentsBody = () => {
         <Divider sx={{ mt: 2, mb: isTrendsSeriesDataAvailable ? 4 : 2 }} />
         {isTrendsSeriesDataAvailable ? (
           <FlexBox fullWidth height={'300px'} alignCenter justifyCenter p={1}>
-            <TrendsLineChart series={trendsSeriesMap.meanTimeToRestoreTrends} />
+            <TrendsLineChart
+              series={trendsSeriesMap.meanTimeToRestoreTrends}
+              isTimeBased
+            />
           </FlexBox>
         ) : (
           <Line>Not enough data to show trends.</Line>

--- a/web-server/src/content/PullRequests/TeamInsightsBody.tsx
+++ b/web-server/src/content/PullRequests/TeamInsightsBody.tsx
@@ -210,7 +210,7 @@ export const TeamInsightsBodyRouterless: FC<{
                   justifyCenter
                   p={1}
                 >
-                  <TrendsLineChart series={series} />
+                  <TrendsLineChart series={series} isTimeBased />
                 </FlexBox>
                 <LegendsMenu series={series} />
               </FlexBox>


### PR DESCRIPTION
## Linked Issue(s) 

#335

## Change-log

- fixes time based trendsline graph

## Before

<img width="1252" alt="image" src="https://github.com/middlewarehq/middleware/assets/76566992/73dd7cd0-e8ac-4039-94f6-04ad24b97879">

## After

<img width="1270" alt="image" src="https://github.com/middlewarehq/middleware/assets/76566992/ab203a69-91b7-4e9e-93a2-eb2dcb427a3e">



