### PR TITLE
Loading states for sync-in-progress

### DIFF
--- a/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
+++ b/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
@@ -2,13 +2,13 @@ import { endOfDay, startOfDay } from 'date-fns';
 import * as yup from 'yup';
 
 import { getTeamRepos } from '@/api/resources/team_repos';
+import { getBookmarkedRepos } from '@/api/resources/teams/[team_id]/bookmarked_repos';
 import { Endpoint } from '@/api-helpers/global';
 import {
   repoFiltersFromTeamProdBranches,
   updatePrFilterParams,
   workFlowFiltersFromTeamProdBranches
 } from '@/api-helpers/team';
-import { Table } from '@/constants/db';
 import { mockDoraMetrics } from '@/mocks/dora_metrics';
 import { TeamDoraMetricsApiResponseType } from '@/types/resources';
 import {
@@ -18,7 +18,6 @@ import {
   fetchDeploymentFrequencyStats
 } from '@/utils/cockpitMetricUtils';
 import { isoDateString, getAggregateAndTrendsIntervalTime } from '@/utils/date';
-import { db } from '@/utils/db';
 
 import { getTeamLeadTimePRs } from './insights';
 import { getAllTeamsReposProdBranchesForOrgAsMap } from './repo_branches';
@@ -179,20 +178,3 @@ endpoint.handle.GET(getSchema, async (req, res) => {
 });
 
 export default endpoint.serve();
-
-export const getBookmarkedRepos = async (teamId?: ID) => {
-  const query = db(Table.Bookmark).select('repo_id');
-
-  if (!teamId)
-    return (await query.then((res) =>
-      res.map((item) => item?.repo_id)
-    )) as ID[];
-
-  const teamRepoIds = await getTeamRepos(teamId).then((res) =>
-    res.map((repo) => repo.id)
-  );
-
-  return (await query
-    .whereIn('repo_id', teamRepoIds)
-    .then((res) => res.map((item) => item?.repo_id))) as ID[];
-};

--- a/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
+++ b/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
@@ -181,5 +181,7 @@ endpoint.handle.GET(getSchema, async (req, res) => {
 export default endpoint.serve();
 
 export const getBookmarkedRepos = async () => {
-  return await db(Table.Bookmark).select('*');
+  return (await db(Table.Bookmark)
+    .select('repo_id')
+    .then((res) => res.map((item) => item?.repo_id))) as ID[];
 };

--- a/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
+++ b/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
@@ -175,7 +175,7 @@ endpoint.handle.GET(getSchema, async (req, res) => {
     lead_time_prs: leadtimePrs,
     assigned_repos: teamRepos,
     bookmarked_repos: bookmarkedRepos
-  } as TeamDoraMetricsApiResponseType & any);
+  } as TeamDoraMetricsApiResponseType);
 });
 
 export default endpoint.serve();

--- a/web-server/pages/api/resources/teams/[team_id]/bookmarked_repos.ts
+++ b/web-server/pages/api/resources/teams/[team_id]/bookmarked_repos.ts
@@ -14,7 +14,7 @@ const endpoint = new Endpoint(pathSchema);
 
 endpoint.handle.GET(nullSchema, async (req, res) => {
   if (req.meta?.features?.use_mock_data) {
-    return res.send([1, 2, 3].map(() => uuid()));
+    return res.send([uuid(), uuid()]);
   }
 
   res.send(await getBookmarkedRepos(req.payload.team_id));

--- a/web-server/pages/api/resources/teams/[team_id]/bookmarked_repos.ts
+++ b/web-server/pages/api/resources/teams/[team_id]/bookmarked_repos.ts
@@ -1,0 +1,40 @@
+import * as yup from 'yup';
+
+import { getTeamRepos } from '@/api/resources/team_repos';
+import { Endpoint, nullSchema } from '@/api-helpers/global';
+import { Table } from '@/constants/db';
+import { uuid } from '@/utils/datatype';
+import { db } from '@/utils/db';
+
+const pathSchema = yup.object().shape({
+  team_id: yup.string().uuid().required()
+});
+
+const endpoint = new Endpoint(pathSchema);
+
+endpoint.handle.GET(nullSchema, async (req, res) => {
+  if (req.meta?.features?.use_mock_data) {
+    return res.send([1, 2, 3].map(() => uuid()));
+  }
+
+  res.send(await getBookmarkedRepos(req.payload.team_id));
+});
+
+export const getBookmarkedRepos = async (teamId?: ID) => {
+  const query = db(Table.Bookmark).select('repo_id');
+
+  if (!teamId)
+    return (await query.then((res) =>
+      res.map((item) => item?.repo_id)
+    )) as ID[];
+
+  const teamRepoIds = await getTeamRepos(teamId).then((res) =>
+    res.map((repo) => repo.id)
+  );
+
+  return (await query
+    .whereIn('repo_id', teamRepoIds)
+    .then((res) => res.map((item) => item?.repo_id))) as ID[];
+};
+
+export default endpoint.serve();

--- a/web-server/pages/dora-metrics/index.tsx
+++ b/web-server/pages/dora-metrics/index.tsx
@@ -1,17 +1,19 @@
-import { Chip } from '@mui/material';
 import ExtendedSidebarLayout from 'src/layouts/ExtendedSidebarLayout';
 
 import { Authenticated } from '@/components/Authenticated';
 import { FlexBox } from '@/components/FlexBox';
 import Loader from '@/components/Loader';
+import { Loader as MiniLoading } from '@/components/Teams/CreateTeams';
 import { FetchState } from '@/constants/ui-states';
 import { useRedirectWithSession } from '@/constants/useRoute';
-import { DoraMetricsBody } from '@/content/DoraMetrics/DoraMetricsBody';
+import {
+  DoraMetricsBody,
+  useSyncedRepos
+} from '@/content/DoraMetrics/DoraMetricsBody';
 import { PageWrapper } from '@/content/PullRequests/PageWrapper';
 import { useAuth } from '@/hooks/useAuth';
 import { useSelector } from '@/store';
 import { PageLayout } from '@/types/resources';
-
 function Page() {
   useRedirectWithSession();
   const isLoading = useSelector(
@@ -21,6 +23,8 @@ function Page() {
     integrations: { github: isGithubIntegrated }
   } = useAuth();
 
+  const { isSyncing } = useSyncedRepos();
+
   return (
     <PageWrapper
       title={
@@ -28,6 +32,15 @@ function Page() {
           DORA metrics
         </FlexBox>
       }
+      additionalFilters={[
+        <FlexBox fullWidth justifyEnd key="loader">
+          {isSyncing && (
+            <FlexBox>
+              <MiniLoading label="Repo sync in progress" />
+            </FlexBox>
+          )}
+        </FlexBox>
+      ]}
       pageTitle="DORA metrics"
       isLoading={isLoading}
       teamDateSelectorMode="single"

--- a/web-server/pages/dora-metrics/index.tsx
+++ b/web-server/pages/dora-metrics/index.tsx
@@ -3,13 +3,9 @@ import ExtendedSidebarLayout from 'src/layouts/ExtendedSidebarLayout';
 import { Authenticated } from '@/components/Authenticated';
 import { FlexBox } from '@/components/FlexBox';
 import Loader from '@/components/Loader';
-import { Loader as MiniLoading } from '@/components/Teams/CreateTeams';
 import { FetchState } from '@/constants/ui-states';
 import { useRedirectWithSession } from '@/constants/useRoute';
-import {
-  DoraMetricsBody,
-  useSyncedRepos
-} from '@/content/DoraMetrics/DoraMetricsBody';
+import { DoraMetricsBody } from '@/content/DoraMetrics/DoraMetricsBody';
 import { PageWrapper } from '@/content/PullRequests/PageWrapper';
 import { useAuth } from '@/hooks/useAuth';
 import { useSelector } from '@/store';
@@ -23,8 +19,6 @@ function Page() {
     integrations: { github: isGithubIntegrated }
   } = useAuth();
 
-  const { isSyncing } = useSyncedRepos();
-
   return (
     <PageWrapper
       title={
@@ -32,15 +26,6 @@ function Page() {
           DORA metrics
         </FlexBox>
       }
-      additionalFilters={[
-        <FlexBox fullWidth justifyEnd key="loader">
-          {isSyncing && (
-            <FlexBox>
-              <MiniLoading label="Repo sync in progress" />
-            </FlexBox>
-          )}
-        </FlexBox>
-      ]}
       pageTitle="DORA metrics"
       isLoading={isLoading}
       teamDateSelectorMode="single"

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -83,11 +83,11 @@ const TeamsCRUD: FC<CRUDProps> = ({
   );
 };
 
-export const Loader = () => {
+export const Loader: FC<{ label?: string }> = ({ label = 'Loading...' }) => {
   return (
     <FlexBox alignCenter gap2>
       <CircularProgress size="20px" />
-      <Line>Loading...</Line>
+      <Line>{label}</Line>
     </FlexBox>
   );
 };

--- a/web-server/src/content/DoraMetrics/DoraMetricsBody.tsx
+++ b/web-server/src/content/DoraMetrics/DoraMetricsBody.tsx
@@ -92,7 +92,7 @@ export const DoraMetricsBody = () => {
 
   const stats = useDoraStats();
 
-  const { isFreshOrg } = useFreshOrgCalculator();
+  const { isSyncing } = useSyncedRepos();
 
   if (isErrored)
     return (
@@ -103,12 +103,18 @@ export const DoraMetricsBody = () => {
     );
   if (!firstLoadDone) return <MiniLoader label={getRandomLoadMsg()} />;
   if (isTeamInsightsEmpty)
-    if (isFreshOrg)
+    if (isSyncing)
       return (
         <EmptyState
           type="SYNC_IN_PROGRESS"
           title="Sync in progress"
-          desc="Your data is syncing. Please reload in a few minutes."
+          desc={
+            <FlexBox gap={1}>
+              <MiniLoader
+                label={'Your repos are syncing, please wait for a few minutes'}
+              />
+            </FlexBox>
+          }
         >
           <FixedContentRefreshLoader show={isLoading} />
         </EmptyState>

--- a/web-server/src/content/PullRequests/PageWrapper.tsx
+++ b/web-server/src/content/PullRequests/PageWrapper.tsx
@@ -18,6 +18,7 @@ export const PageWrapper: FC<{
   headerChildren?: ReactNode;
   isLoading?: boolean;
   showEvenIfNoTeamSelected?: boolean;
+  additionalFilters?: ReactNode[];
 }> = ({
   title = 'Collaborate',
   hideAllSelectors,
@@ -27,7 +28,8 @@ export const PageWrapper: FC<{
   teamDateSelectorMode,
   headerChildren,
   isLoading,
-  showEvenIfNoTeamSelected = false
+  showEvenIfNoTeamSelected = false,
+  additionalFilters = []
 }) => {
   const { noTeamSelected } = useSingleTeamConfig();
   // TODO: use fetchState
@@ -45,6 +47,7 @@ export const PageWrapper: FC<{
           teamDateSelectorMode={
             teamDateSelectorMode || (showDate ? 'single' : 'single-only')
           }
+          additionalFilters={additionalFilters}
           selectBranch
         >
           {headerChildren}

--- a/web-server/src/slices/dora_metrics.ts
+++ b/web-server/src/slices/dora_metrics.ts
@@ -101,9 +101,7 @@ export const doraMetricsSlice = createSlice({
         );
         state.allReposAssignedToTeam = action.payload.assigned_repos;
         state.summary_prs = action.payload.lead_time_prs;
-        state.bookmarkedRepos = action.payload.bookmarked_repos.map(
-          (item) => item.repo_id
-        );
+        state.bookmarkedRepos = action.payload.bookmarked_repos;
       }
     );
     addFetchCasesToReducer(

--- a/web-server/src/slices/dora_metrics.ts
+++ b/web-server/src/slices/dora_metrics.ts
@@ -38,6 +38,7 @@ export type State = StateFetchConfig<{
   deployments_map: Record<string, Deployment>;
   revert_prs: PR[];
   summary_prs: PR[];
+  bookmarkedRepos: ID[];
 }>;
 
 const initialState: State = {
@@ -56,7 +57,8 @@ const initialState: State = {
   prs_map: {},
   deployments_map: {},
   revert_prs: [],
-  summary_prs: []
+  summary_prs: [],
+  bookmarkedRepos: []
 };
 
 export const doraMetricsSlice = createSlice({
@@ -99,6 +101,9 @@ export const doraMetricsSlice = createSlice({
         );
         state.allReposAssignedToTeam = action.payload.assigned_repos;
         state.summary_prs = action.payload.lead_time_prs;
+        state.bookmarkedRepos = action.payload.bookmarked_repos.map(
+          (item) => item.repo_id
+        );
       }
     );
     addFetchCasesToReducer(

--- a/web-server/src/slices/team.ts
+++ b/web-server/src/slices/team.ts
@@ -48,7 +48,7 @@ const initialState: State = {
   teamReposProductionBranches: [],
   teamIncidentFilters: null,
   excludedPrs: [],
-  teamReposMaps: null
+  teamReposMaps: {}
 };
 
 export const teamSlice = createSlice({

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -577,6 +577,7 @@ export type TeamDoraMetricsApiResponseType = {
   };
   lead_time_prs: PR[];
   assigned_repos: (Row<'TeamRepos'> & Row<'OrgRepo'>)[];
+  bookmarked_repos: Row<'Bookmark'>[];
 };
 
 export enum ActiveBranchMode {

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -577,7 +577,7 @@ export type TeamDoraMetricsApiResponseType = {
   };
   lead_time_prs: PR[];
   assigned_repos: (Row<'TeamRepos'> & Row<'OrgRepo'>)[];
-  bookmarked_repos: Row<'Bookmark'>[];
+  bookmarked_repos: ID[];
 };
 
 export enum ActiveBranchMode {


### PR DESCRIPTION
## Issues linked
#340 

### Start
https://github.com/middlewarehq/middleware/assets/76566992/c7bfbec6-1054-476d-a1c3-a2ecf285c636

### End
https://github.com/middlewarehq/middleware/assets/76566992/4b4b3201-fe04-4452-99d6-0f5e14e1c53d

- Adds the `bookmarked_repos` field to the Dora Metrics API response. The field contains an array of bookmarked repository IDs. 
- Additionally, a new function `getBookmarkedRepos` is implemented to fetch the bookmarked repos for a specific team.
- Loading states for sync-in-progress was made using a hook that polls and watches if repos are synced or not
- changed fresh-org logic and created a hook to check and poll dora-metrics API to see if repos are synced or not