### PR TITLE
Rename API endpoint and handle unsynced repos

### DIFF
--- a/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
+++ b/web-server/pages/api/internal/team/[team_id]/dora_metrics.ts
@@ -2,7 +2,7 @@ import { endOfDay, startOfDay } from 'date-fns';
 import * as yup from 'yup';
 
 import { getTeamRepos } from '@/api/resources/team_repos';
-import { getBookmarkedRepos } from '@/api/resources/teams/[team_id]/bookmarked_repos';
+import { getUnsyncedRepos } from '@/api/resources/teams/[team_id]/unsynced_repos';
 import { Endpoint } from '@/api-helpers/global';
 import {
   repoFiltersFromTeamProdBranches,
@@ -49,9 +49,9 @@ endpoint.handle.GET(getSchema, async (req, res) => {
     branches
   } = req.payload;
 
-  const [teamProdBranchesMap, bookmarkedRepos] = await Promise.all([
+  const [teamProdBranchesMap, unsyncedRepos] = await Promise.all([
     getAllTeamsReposProdBranchesForOrgAsMap(org_id),
-    getBookmarkedRepos(teamId)
+    getUnsyncedRepos(teamId)
   ]);
   const teamRepoFiltersMap =
     repoFiltersFromTeamProdBranches(teamProdBranchesMap);
@@ -173,7 +173,7 @@ endpoint.handle.GET(getSchema, async (req, res) => {
       deploymentFrequencyResponse.deployment_frequency_trends,
     lead_time_prs: leadtimePrs,
     assigned_repos: teamRepos,
-    bookmarked_repos: bookmarkedRepos
+    unsynced_repos: unsyncedRepos
   } as TeamDoraMetricsApiResponseType);
 });
 

--- a/web-server/src/content/DoraMetrics/DoraCards/SkeletalCard.tsx
+++ b/web-server/src/content/DoraMetrics/DoraCards/SkeletalCard.tsx
@@ -53,6 +53,7 @@ const SkeletalCard: FC<{ animation?: boolean }> = ({ animation }) => {
       minHeight={'15em'}
       component={Paper}
       col
+      boxShadow={'none !important'}
       relative
       width={'100%'}
       flexGrow={1}

--- a/web-server/src/content/DoraMetrics/DoraMetricsBody.tsx
+++ b/web-server/src/content/DoraMetrics/DoraMetricsBody.tsx
@@ -1,6 +1,6 @@
 import { Grid, Divider, Button } from '@mui/material';
 import Link from 'next/link';
-import { FC, useEffect, useMemo } from 'react';
+import { FC, useEffect } from 'react';
 
 import { DoraMetricsConfigurationSettings } from '@/components/DoraMetricsConfigurationSettings';
 import { DoraScore } from '@/components/DoraScore';
@@ -186,12 +186,7 @@ export const useSyncedRepos = () => {
 
   const reposMap = useSelector((s) => s.team.teamReposMaps);
   const { singleTeamId } = useSingleTeamConfig();
-  const syncedRepos = useSelector((s) => s.doraMetrics.bookmarkedRepos);
-
-  const isSyncing = useMemo(() => {
-    const teamRepos = reposMap[singleTeamId] || [];
-    return !teamRepos.every((repo) => syncedRepos.includes(repo.id));
-  }, [reposMap, singleTeamId, syncedRepos]);
+  const isSyncing = useSelector((s) => s.doraMetrics.unsyncedRepos.length);
 
   useEffect(() => {
     if (!isSyncing) return;
@@ -205,7 +200,6 @@ export const useSyncedRepos = () => {
 
   return {
     isSyncing,
-    syncedRepos,
     teamRepos: reposMap[singleTeamId] || []
   };
 };
@@ -242,6 +236,7 @@ export const LoaderCore: FC<{
 }> = ({ animation }) => {
   return (
     <FlexBox
+      fullWidth
       gap={4}
       sx={{
         transition: `opacity ${ANIMATON_DURATION}ms linear, height 300ms ease, margin 300ms ease`,

--- a/web-server/src/slices/dora_metrics.ts
+++ b/web-server/src/slices/dora_metrics.ts
@@ -38,7 +38,7 @@ export type State = StateFetchConfig<{
   deployments_map: Record<string, Deployment>;
   revert_prs: PR[];
   summary_prs: PR[];
-  bookmarkedRepos: ID[];
+  unsyncedRepos: ID[];
 }>;
 
 const initialState: State = {
@@ -58,7 +58,7 @@ const initialState: State = {
   deployments_map: {},
   revert_prs: [],
   summary_prs: [],
-  bookmarkedRepos: []
+  unsyncedRepos: []
 };
 
 export const doraMetricsSlice = createSlice({
@@ -101,7 +101,7 @@ export const doraMetricsSlice = createSlice({
         );
         state.allReposAssignedToTeam = action.payload.assigned_repos;
         state.summary_prs = action.payload.lead_time_prs;
-        state.bookmarkedRepos = action.payload.bookmarked_repos;
+        state.unsyncedRepos = action.payload.unsynced_repos;
       }
     );
     addFetchCasesToReducer(
@@ -136,8 +136,8 @@ export const doraMetricsSlice = createSlice({
     addFetchCasesToReducer(
       builder,
       getSyncedRepos,
-      'bookmarkedRepos',
-      (state, action) => (state.bookmarkedRepos = action.payload)
+      'unsyncedRepos',
+      (state, action) => (state.unsyncedRepos = action.payload)
     );
   }
 });
@@ -218,7 +218,7 @@ export const getSyncedRepos = createAsyncThunk(
   'dora_metrics/getSyncedRepos',
   async (params: { team_id: ID }) => {
     return await handleApi<ID[]>(
-      `/resources/teams/${params.team_id}/bookmarked_repos`
+      `/resources/teams/${params.team_id}/unsynced_repos`
     );
   }
 );

--- a/web-server/src/slices/dora_metrics.ts
+++ b/web-server/src/slices/dora_metrics.ts
@@ -135,7 +135,7 @@ export const doraMetricsSlice = createSlice({
     );
     addFetchCasesToReducer(
       builder,
-      getSyncedRepos,
+      getUnyncedRepos,
       'unsyncedRepos',
       (state, action) => (state.unsyncedRepos = action.payload)
     );
@@ -214,8 +214,8 @@ export const fetchDeploymentPRs = createAsyncThunk(
   }
 );
 
-export const getSyncedRepos = createAsyncThunk(
-  'dora_metrics/getSyncedRepos',
+export const getUnyncedRepos = createAsyncThunk(
+  'dora_metrics/getUnyncedRepos',
   async (params: { team_id: ID }) => {
     return await handleApi<ID[]>(
       `/resources/teams/${params.team_id}/unsynced_repos`

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -577,7 +577,7 @@ export type TeamDoraMetricsApiResponseType = {
   };
   lead_time_prs: PR[];
   assigned_repos: (Row<'TeamRepos'> & Row<'OrgRepo'>)[];
-  bookmarked_repos: ID[];
+  unsynced_repos: ID[];
 };
 
 export enum ActiveBranchMode {


### PR DESCRIPTION
## Change-log
- the entire dora-calculation was re-fetched for polling
- instead a simple `unsynced_repos` function is now utilized
- hence the renaming of several variables 

### changes
- renames API endpoint and changes function to send unsynced repos only
- removes border from the loading skeletal
- renames bookmarked_repos to unsynced, handles logic accordingly
- renamed thunk to getUnyncedRepos
- utilizes unsynced_repos as the polling API, finally calls dora-api