### PR TITLE
Fix broken link to MTTR external resource

### DIFF
--- a/web-server/src/content/DoraMetrics/DoraCards/MeanTimeToRestoreCard.tsx
+++ b/web-server/src/content/DoraMetrics/DoraCards/MeanTimeToRestoreCard.tsx
@@ -104,7 +104,7 @@ export const MeanTimeToRestoreCard = () => {
               }}
             >
               <MetricExternalRead
-                link={`https://docs.gitlab.com/ee/user/analytics/dora_metrics.html#time-to-restore-service`}
+                link={`https://www.middlewarehq.com/blog/mttr-deep-dive-a-technical-guide-for-engineering-managers-leaders`}
                 label="Mean Time to Recovery"
               />
             </FlexBox>


### PR DESCRIPTION
The link to the Mean Time to Restore (MTTR) external resource was pointing to the wrong URL. This pull request fixes the link by updating it to the correct URL.