### PR TITLE
Refactor deployment_analytics.ts API endpoint and fetchTeamDeployments thunk

### DIFF
--- a/web-server/pages/api/internal/team/[team_id]/deployment_analytics.ts
+++ b/web-server/pages/api/internal/team/[team_id]/deployment_analytics.ts
@@ -3,15 +3,21 @@ import * as yup from 'yup';
 
 import { handleRequest } from '@/api-helpers/axios';
 import { Endpoint } from '@/api-helpers/global';
+import { updatePrFilterParams } from '@/api-helpers/team';
 import { Row } from '@/constants/db';
 import { mockDeploymentFreq } from '@/mocks/deployment-freq';
 import {
   RepoWorkflowExtended,
-  UpdatedTeamDeploymentsApiResponse
+  UpdatedTeamDeploymentsApiResponse,
+  ActiveBranchMode
 } from '@/types/resources';
 import { adaptedDeploymentsMap } from '@/utils/adapt_deployments';
 import { isoDateString } from '@/utils/date';
 import { db } from '@/utils/db';
+import {
+  getBranchesAndRepoFilter,
+  getWorkFlowFiltersAsPayloadForSingleTeam
+} from '@/utils/filterUtils';
 import groupBy from '@/utils/objectArray';
 
 const pathSchema = yup.object().shape({
@@ -19,9 +25,12 @@ const pathSchema = yup.object().shape({
 });
 
 const getSchema = yup.object().shape({
+  org_id: yup.string().uuid().required(),
+  team_id: yup.string().uuid().required(),
+  branch_mode: yup.string().oneOf(Object.values(ActiveBranchMode)).required(),
+  branches: yup.string().optional().nullable(),
   from_date: yup.date().required(),
-  to_date: yup.date().required(),
-  branches: yup.string().optional().nullable()
+  to_date: yup.date().required()
 });
 
 const endpoint = new Endpoint(pathSchema);
@@ -29,15 +38,36 @@ const endpoint = new Endpoint(pathSchema);
 endpoint.handle.GET(getSchema, async (req, res) => {
   if (req.meta?.features?.use_mock_data) return res.send(mockDeploymentFreq);
 
-  const { team_id, from_date, to_date } = req.payload;
+  const { org_id, branch_mode, branches, team_id, from_date, to_date } =
+    req.payload;
 
+  const branchAndRepoFilters = await getBranchesAndRepoFilter({
+    orgId: org_id,
+    teamId: team_id,
+    branchMode: branch_mode as ActiveBranchMode,
+    branches
+  });
+
+  const [prFilters, workflowFilters] = await Promise.all([
+    updatePrFilterParams(team_id, {}, branchAndRepoFilters).then(
+      ({ pr_filter }) => ({
+        pr_filter
+      })
+    ),
+    getWorkFlowFiltersAsPayloadForSingleTeam({
+      orgId: org_id,
+      teamId: team_id
+    })
+  ]);
   const [updatedResponse, workflows_map] = await Promise.all([
     handleRequest<UpdatedTeamDeploymentsApiResponse>(
       `/teams/${team_id}/deployment_analytics`,
       {
         params: reject(isNil, {
           from_time: isoDateString(new Date(from_date)),
-          to_time: isoDateString(new Date(to_date))
+          to_time: isoDateString(new Date(to_date)),
+          pr_filter: prFilters.pr_filter,
+          workflow_filter: workflowFilters.workflow_filter
         })
       }
     ),

--- a/web-server/src/content/PullRequests/DeploymentInsightsOverlay.tsx
+++ b/web-server/src/content/PullRequests/DeploymentInsightsOverlay.tsx
@@ -12,11 +12,12 @@ import { PullRequestsTableMini } from '@/components/PRTableMini/PullRequestsTabl
 import Scrollbar from '@/components/Scrollbar';
 import { Line } from '@/components/Text';
 import { FetchState } from '@/constants/ui-states';
+import { useAuth } from '@/hooks/useAuth';
 import { useBoolState, useEasyState } from '@/hooks/useEasyState';
 import {
-  useStateBranchConfig,
   useSingleTeamConfig,
-  useCurrentDateRangeReactNode
+  useCurrentDateRangeReactNode,
+  useBranchesForPrFilters
 } from '@/hooks/useStateTeamConfig';
 import { useTableSort } from '@/hooks/useTableSort';
 import {
@@ -40,11 +41,11 @@ enum DepStatusFilter {
 const hideTableColumns = new Set<keyof PR>(['reviewers', 'rework_cycles']);
 
 export const DeploymentInsightsOverlay = () => {
+  const { orgId } = useAuth();
   const { singleTeamId, team, dates } = useSingleTeamConfig();
-  const branches = useStateBranchConfig();
   const dispatch = useDispatch();
   const depFilter = useEasyState(DepStatusFilter.All);
-
+  const branchesForPrFilters = useBranchesForPrFilters();
   useEffect(() => {
     if (!singleTeamId) return;
 
@@ -52,10 +53,19 @@ export const DeploymentInsightsOverlay = () => {
       fetchTeamDeployments({
         team_id: singleTeamId,
         from_date: dates.start,
-        to_date: dates.end
+        to_date: dates.end,
+        org_id: orgId,
+        ...branchesForPrFilters
       })
     );
-  }, [branches, dates.end, dates.start, dispatch, singleTeamId]);
+  }, [
+    branchesForPrFilters,
+    dates.end,
+    dates.start,
+    dispatch,
+    orgId,
+    singleTeamId
+  ]);
 
   const teamDeployments = useSelector((s) => s.doraMetrics.team_deployments);
   const workflowsMap = useSelector(

--- a/web-server/src/slices/dora_metrics.ts
+++ b/web-server/src/slices/dora_metrics.ts
@@ -200,7 +200,7 @@ export const fetchAllResolvedIncidents = createAsyncThunk(
 
 export const fetchTeamDeployments = createAsyncThunk(
   'dora_metrics/fetchTeamDeployments',
-  async (params: DoraMetricsApiParamsType) => {
+  async (params: DoraMetricsApiParamsType & { org_id: ID }) => {
     return await handleApi<TeamDeploymentsApiResponse>(
       `/internal/team/${params.team_id}/deployment_analytics`,
       { params }


### PR DESCRIPTION
This pull request refactors the deployment_analytics.ts API endpoint and the fetchTeamDeployments thunk to use updated filter utilities. The changes include updating the API endpoint to use the updated filter utilities and updating the thunk to pass the necessary parameters for the filters. This improves the efficiency and accuracy of the deployment analytics feature.