### PR TITLE
fix: fixed pr sorting

### DIFF
--- a/web-server/src/components/PRTable/PullRequestsTableHead.tsx
+++ b/web-server/src/components/PRTable/PullRequestsTableHead.tsx
@@ -87,9 +87,9 @@ export const PullRequestsTableHead: FC<PullRequestsTableHeadProps> = ({
         )}
         <TableCell sx={{ minWidth: '40%', p: CELL_PAD, py: 1.5 }}>
           <TableSortLabel
-            direction={conf.field === 'title' ? conf.order : 'asc'}
-            active={conf.field === 'title'}
-            onClick={() => updateSortConf('title')}
+            direction={conf.field === 'number' ? conf.order : 'asc'}
+            active={conf.field === 'number'}
+            onClick={() => updateSortConf('number')}
           >
             Pull Request
           </TableSortLabel>


### PR DESCRIPTION
This pull request updates the sorting functionality for the pull request header. Previously, clicking the header sorted by title; now it sorts by pr number (#).

## Linked Issue(s) 
fixes #396 
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->