### PR TITLE
Update ImageUpdateBanner component and instructions layout

### DIFF
--- a/web-server/src/components/ImageUpdateBanner.tsx
+++ b/web-server/src/components/ImageUpdateBanner.tsx
@@ -1,9 +1,9 @@
 import CloseIcon from '@mui/icons-material/Close';
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
 import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 import {
   Divider,
   Button,
-  Card,
   useTheme,
   Dialog,
   Slide,
@@ -22,13 +22,16 @@ import { useModal } from '@/contexts/ModalContext';
 import { useEasyState } from '@/hooks/useEasyState';
 import { appSlice } from '@/slices/app';
 import { useDispatch, useSelector } from '@/store';
-import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
 
 const FETCH_LATEST_IMAGE_INSTRUCTIONS = [
   `docker stop middleware  `,
   `docker pull middlewareeng/middleware:latest
 docker rm -f middleware || true
-docker run --name middleware -p 3333:3333 -v middleware_postgres_data:/var/lib/postgresql/data -v middleware_keys:/app/keys -d middlewareeng/middleware:latest
+docker run --name middleware 
+           -p 3333:3333 
+           -v middleware_postgres_data:/var/lib/postgresql/data 
+           -v middleware_keys:/app/keys 
+           -d middlewareeng/middleware:latest
 docker logs -f middleware  `,
   `docker rm -f middleware  `
 ];
@@ -70,7 +73,7 @@ export const ImageUpdateBanner = () => {
     addModal({
       title: `Update Image Instructions`,
       body: (
-        <FlexBox col fullWidth>
+        <FlexBox col maxWidth="900px">
           <Line>
             We've just released a new image release for your self-hosted Dora.
             Update your image now to get the latest features and improvements.
@@ -99,6 +102,7 @@ export const ImageUpdateBanner = () => {
                 Conflict. The container name "/middleware" is already in use by
                 container.
               </Line>{' '}
+              <br />
               Then run following command before running the container again:
               <CopyDockerCommandComponent
                 text={FETCH_LATEST_IMAGE_INSTRUCTIONS[2]}


### PR DESCRIPTION
This pull request updates the ImageUpdateBanner component and instructions layout. The changes include importing the ContentCopyRoundedIcon and removing unused imports. The maxWidth of the FlexBox component has been set to 900px for better layout. Additionally, the body of the ImageUpdateBanner component has been updated to include a line break and a CopyDockerCommandComponent. These changes improve the appearance and functionality of the ImageUpdateBanner component.