### PR TITLE
Fix: sort reviewers by Name

### DIFF
--- a/web-server/src/components/PRTable/PullRequestsTable.tsx
+++ b/web-server/src/components/PRTable/PullRequestsTable.tsx
@@ -421,6 +421,8 @@ export const PullRequestsTable: FC<
 
 const PrReviewersCell: FC<{ pr: PR }> = ({ pr }) => {
   const theme = useTheme();
+  const sortedReviewers = [...pr.reviewers].sort((a, b) => a.username.localeCompare(b.username));
+
   return (
     <FlexBox
       alignCenter
@@ -430,7 +432,7 @@ const PrReviewersCell: FC<{ pr: PR }> = ({ pr }) => {
       flexWrap="wrap"
       maxWidth="60px"
     >
-      {pr.reviewers.map((reviewer) => (
+      {sortedReviewers.map((reviewer) => (
         <FlexBox
           title={
             <Box>


### PR DESCRIPTION
## Linked Issue(s) 

#398 

## Acceptance Criteria fulfillment

- [x]  When sorting Reviewers, the number of reviewers is the primary sort, and alphabetically after that

## Proposed changes (including videos or screenshots)
## Before 
![image](https://github.com/middlewarehq/middleware/assets/99081689/92841b40-4573-4668-b49c-904443be5afa)
## After 
![image](https://github.com/middlewarehq/middleware/assets/99081689/8f1d1f42-674b-4554-baf9-5633edfb129b)


