### PR TITLE
fix: added code to ensure proper execution for newer versions of docker

### DIFF
--- a/cli/source/constants.ts
+++ b/cli/source/constants.ts
@@ -32,6 +32,10 @@ export enum LogSource {
   DockerWatchProcessIdLock
 }
 
+export enum ErrorCodes {
+  SpawnProcessCommandNotFound = '-2'
+}
+
 export type LogEntry = {
   type:
     | 'data'

--- a/cli/source/utils/run-command.ts
+++ b/cli/source/utils/run-command.ts
@@ -5,6 +5,7 @@ import {
 } from 'child_process';
 
 import CircularBuffer from './circularBuffer.js';
+
 import { LogSource, READY_MESSAGES } from '../constants.js';
 
 export function runCommand(

--- a/dev.sh
+++ b/dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose down
+docker compose down
 
 [ ! -f .env ] && cp env.example .env
 


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
#383 
## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [x] Running the dev.sh script should properly start the development container, regardless of docker version.

## Changes

This PR fixes the call for docker compose within the cli. Right now, `docker-compose` is being used, but as of the newer versions (as stated [here](https://docs.docker.com/compose/migrate/)) , the compose command has been integrated into docker desktop itself. So we should be using `docker compose` instead.

For the sake of backwards compatibility, some code has been included to run the old command should the newer one fails.
