### PR TITLE
run docker compose build before running docker compose watch to sync any local files changes between container restarts

### DIFF
--- a/cli/source/app.tsx
+++ b/cli/source/app.tsx
@@ -150,7 +150,7 @@ const CliUi = () => {
         })
       );
     });
-  }, [dispatch, exit, handleExit, runCommandOpts]);
+  }, []);
 
   useEffect(() => {
     const { process, promise } = runCommand(


### PR DESCRIPTION
## Linked Issue(s) 
#353 

This PR fixes the above linked issue. We run `docker compose build` before starting the `docker compose watch` which would rebuild the container with local changes. 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Steps to check
1. Run `dev.sh` to start the dev cli
2. Make local code changes and check if those has been synced and the changes are reflected in the app
3. Close the dev cli and then start it again
4. Check if the local changes are synced

