### PR TITLE
Revert "Limit access for Database and Backend Servers for developer environment"

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -41,8 +41,7 @@ RUN mkdir -p /etc/cron.d && mv /app/setup_utils/cronjob.txt /etc/cron.d/cronjob
 RUN chmod +x /app/setup_utils/start.sh /app/setup_utils/init_db.sh /app/setup_utils/generate_config_ini.sh
 RUN mv /app/setup_utils/supervisord.conf /etc/supervisord.conf
 RUN mv /app/database-docker/db/ /app/ && rm -rf /app/database-docker/
-RUN echo "host all  all    127.0.0.1/32  md5" >> /etc/postgresql/15/main/pg_hba.conf
-RUN echo "host all  all    192.168.65.1/32  md5" >> /etc/postgresql/15/main/pg_hba.conf
+RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/15/main/pg_hba.conf
 RUN echo "listen_addresses='*'" >> /etc/postgresql/15/main/postgresql.conf
 RUN sed -i "s/^port = .*/port = ${DB_PORT}/" /etc/postgresql/15/main/postgresql.conf
 RUN npm install --global yarn --force

--- a/cli/source/constants.ts
+++ b/cli/source/constants.ts
@@ -54,8 +54,8 @@ export const keysForLogSource = Object.entries(LogSource).reduce(
 );
 
 export const READY_MESSAGES = {
-  [LogSource.ApiServer]: `Listening at: http://127.0.0.1`,
-  [LogSource.SyncServer]: `Listening at: http://127.0.0.1`,
+  [LogSource.ApiServer]: `Listening at: http://0.0.0.0`,
+  [LogSource.SyncServer]: `Listening at: http://0.0.0.0`,
   [LogSource.WebServer]: [
     `Server started on http://localhost`,
     `http://localhost:`

--- a/setup_utils/start_api_server.sh
+++ b/setup_utils/start_api_server.sh
@@ -21,7 +21,7 @@ wait_for_message
 
 cd /app/backend/analytics_server || exit
 if [ "$ENVIRONMENT" == "prod" ]; then
-  /opt/venv/bin/gunicorn -w 4 -b 127.0.0.1:$API_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' app:app
+  /opt/venv/bin/gunicorn -w 4 -b 0.0.0.0:$API_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' app:app
 else
-  /opt/venv/bin/gunicorn -w 4 -b 127.0.0.1:$API_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' --reload app:app
+  /opt/venv/bin/gunicorn -w 4 -b 0.0.0.0:$API_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' --reload app:app
 fi

--- a/setup_utils/start_sync_server.sh
+++ b/setup_utils/start_sync_server.sh
@@ -21,7 +21,7 @@ wait_for_message
 
 cd /app/backend/analytics_server || exit
 if [ "$ENVIRONMENT" == "prod" ]; then
-  /opt/venv/bin/gunicorn -w 2 -b 127.0.0.1:$SYNC_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' sync_app:app
+  /opt/venv/bin/gunicorn -w 2 -b 0.0.0.0:$SYNC_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' sync_app:app
 else
-  /opt/venv/bin/gunicorn -w 2 -b 127.0.0.1:$SYNC_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' --reload sync_app:app
+  /opt/venv/bin/gunicorn -w 2 -b 0.0.0.0:$SYNC_SERVER_PORT --timeout 0 --access-logfile '-' --error-logfile '-' --reload sync_app:app
 fi


### PR DESCRIPTION
Reverts middlewarehq/middleware#376

This PR is being reverted because the ports are not being mapped to the host machine. This is because the container's network stack is isolated from the host machine. So accessing container's localhost from the host is not possible. 

We can keep the network stack of container isolated and allow all access on `0.0.0.0` and then we could map to only `127.0.0.1` when mapping the port