### PR TITLE
map ports only to localhost on host machine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,11 @@ services:
       - .env
 
     ports:
-      - "${ANALYTICS_SERVER_PORT:-9696}:${ANALYTICS_SERVER_PORT:-9696}"
-      - "${SYNC_SERVER_PORT:-9697}:${SYNC_SERVER_PORT:-9697}"
-      - "${PORT:-3333}:${PORT:-3333}"
-      - "${DB_PORT:-5434}:${DB_PORT:-5434}"
-      - "${REDIS_PORT:-6385}:${REDIS_PORT:-6385}"
+      - "127.0.0.1:${ANALYTICS_SERVER_PORT:-9696}:${ANALYTICS_SERVER_PORT:-9696}"
+      - "127.0.0.1:${SYNC_SERVER_PORT:-9697}:${SYNC_SERVER_PORT:-9697}"
+      - "127.0.0.1:${PORT:-3333}:${PORT:-3333}"
+      - "127.0.0.1:${DB_PORT:-5434}:${DB_PORT:-5434}"
+      - "127.0.0.1:${REDIS_PORT:-6385}:${REDIS_PORT:-6385}"
 
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Earlier ports were being mapped to `0.0.0.0` which would have made the services accessible from any ip on the host machine. This PR makes changes to only map ports to `localhost` on the host machine. This way it is only accessible locally