### PR TITLE
add .gitattributes file to have only Line Feed '\n' as line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat all text files without a CR (as we have Docker)
+* text eol=lf


### PR DESCRIPTION
## Linked Issue(s) 
#430 
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

The above linked issue was caused due to different line endings in a windows system. Windows treats its line ending with 2 characters, i.e, '\r' followed by '\n'. This is not recognised by unix systems and since docker runs a unix system, it was causing problem to start the dev setup on a windows system. This PR adds a `.gitattributes` file, which instructs git  on how to deal with text files, overriding its platform-centric defaults.

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [ ] Task 1
- [ ] Task 2
- [ ] Task 3

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
