### PR TITLE
Update image update status API polling interval to 600,000 milliseconds

### DIFF
--- a/web-server/src/hooks/useImageUpdateStatusWorker.ts
+++ b/web-server/src/hooks/useImageUpdateStatusWorker.ts
@@ -10,7 +10,7 @@ type WorkerResponse = {
 };
 
 const IMAGE_UPDATE_STATUS_API_URL = '/api/internal/version';
-const IMAGE_UPDATE_STATUS_API_POLLING_INTERVAL = 60_000;
+const IMAGE_UPDATE_STATUS_API_POLLING_INTERVAL = 6_00_000;
 
 export const useImageUpdateStatusWorker = (): void => {
   const dispatch = useDispatch();


### PR DESCRIPTION
This pull request updates the image update status API polling interval to 600,000 milliseconds. Previously, the interval was set to 60,000 milliseconds. This change ensures that the polling interval is longer, reducing the frequency of API requests and improving performance.