### PR TITLE
update team repos api to send deployment_type in the response for each repo

### DIFF
--- a/backend/analytics_server/mhq/api/resources/code_resouces.py
+++ b/backend/analytics_server/mhq/api/resources/code_resouces.py
@@ -139,6 +139,27 @@ def adapt_org_repo(org_repo: OrgRepo) -> Dict[str, any]:
     }
 
 
+def adapt_team_repo_and_org_repo(
+    org_repo: OrgRepo, team_repo: TeamRepos
+) -> Dict[str, any]:
+    return {
+        "id": str(org_repo.id),
+        "org_id": str(org_repo.org_id),
+        "name": org_repo.name,
+        "org_name": org_repo.org_name,
+        "provider": org_repo.provider,
+        "is_active": org_repo.is_active,
+        "default_branch": org_repo.default_branch,
+        "language": org_repo.language,
+        "contributors": org_repo.contributors,
+        "idempotency_key": org_repo.idempotency_key,
+        "slug": org_repo.slug,
+        "created_at": org_repo.created_at.isoformat(),
+        "updated_at": org_repo.updated_at.isoformat(),
+        "deployment_type": team_repo.deployment_type.value,
+    }
+
+
 def adapt_team_repos(team_repos: List[TeamRepos]) -> List[Dict[str, any]]:
     return [
         {

--- a/backend/analytics_server/mhq/api/teams.py
+++ b/backend/analytics_server/mhq/api/teams.py
@@ -97,7 +97,7 @@ def fetch_team_repos(team_id: str):
 
     team_repos_service = get_repository_service()
     team_org_repos: List[OrgRepo] = team_repos_service.get_team_repos(team)
-    team_repos: List[TeamRepos] = team_repos_service.get_team_repos_by_team_id(team)
+    team_repos: List[TeamRepos] = team_repos_service.get_team_repos_by_team(team)
     team_id_team_repos_map: Dict[str, TeamRepos] = {
         str(repo.org_repo_id): repo for repo in team_repos
     }

--- a/backend/analytics_server/mhq/service/code/repository_service.py
+++ b/backend/analytics_server/mhq/service/code/repository_service.py
@@ -22,6 +22,9 @@ class RepositoryService:
     def get_team_repos(self, team: Team) -> List[OrgRepo]:
         return self._code_repo_service.get_team_repos(team_id=str(team.id))
 
+    def get_team_repos_by_team_id(self, team: Team) -> List[TeamRepos]:
+        return self._code_repo_service.get_team_repos_by_team_id(team_id=str(team.id))
+
     def update_team_repos(
         self, team: Team, raw_org_repos: List[RawOrgRepo]
     ) -> List[OrgRepo]:

--- a/backend/analytics_server/mhq/service/code/repository_service.py
+++ b/backend/analytics_server/mhq/service/code/repository_service.py
@@ -22,7 +22,7 @@ class RepositoryService:
     def get_team_repos(self, team: Team) -> List[OrgRepo]:
         return self._code_repo_service.get_team_repos(team_id=str(team.id))
 
-    def get_team_repos_by_team_id(self, team: Team) -> List[TeamRepos]:
+    def get_team_repos_by_team(self, team: Team) -> List[TeamRepos]:
         return self._code_repo_service.get_team_repos_by_team_id(team_id=str(team.id))
 
     def update_team_repos(

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -341,6 +341,18 @@ class CodeRepoService:
         return self.get_repos_by_ids(team_repo_ids)
 
     @rollback_on_exc
+    def get_team_repos_by_team_id(self, team_id: str) -> List[TeamRepos]:
+        team_repos = (
+            self._db.session.query(TeamRepos)
+            .filter(and_(TeamRepos.team_id == team_id, TeamRepos.is_active == True))
+            .all()
+        )
+        if not team_repos:
+            return []
+
+        return team_repos
+
+    @rollback_on_exc
     def get_merge_to_deploy_broker_bookmark(
         self, repo_id: str
     ) -> BookmarkMergeToDeployBroker:

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -347,7 +347,6 @@ class CodeRepoService:
             .filter(and_(TeamRepos.team_id == team_id, TeamRepos.is_active == True))
             .all()
         )
-        
 
     @rollback_on_exc
     def get_merge_to_deploy_broker_bookmark(

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -342,15 +342,12 @@ class CodeRepoService:
 
     @rollback_on_exc
     def get_team_repos_by_team_id(self, team_id: str) -> List[TeamRepos]:
-        team_repos = (
+        return (
             self._db.session.query(TeamRepos)
             .filter(and_(TeamRepos.team_id == team_id, TeamRepos.is_active == True))
             .all()
         )
-        if not team_repos:
-            return []
-
-        return team_repos
+        
 
     @rollback_on_exc
     def get_merge_to_deploy_broker_bookmark(


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

- Team repos api `/teams/<team_id>/repos` has been updated to send the `deployment_type` in the response for each repo