### PR TITLE
Update readme to include information relating to setting up `.env` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ To set up middleware locally, follow these steps:
       pip install -r requirements.txt -r dev-requirements.txt
       ```
 
-    - Create a `.env.local` file in the `/backend` directory and add the following environment variables, replacing the values with your own if needed:
+    - Create a `.env` file in the root directory and add the following environment variables, replacing the values with your own if needed:
 
       ```text
       DB_HOST=localhost


### PR DESCRIPTION
## Linked Issue(s) 
#426 
## Proposed Changes
Now the backend reads env variables from the `.env` present at the root directory. The `README` wasn't updated to include this information. I have added the necessary changes in the `README.md` file.