### PR TITLE
handle `deployment_type` updation of team_repos in update team repos api

### DIFF
--- a/backend/analytics_server/mhq/api/request_utils.py
+++ b/backend/analytics_server/mhq/api/request_utils.py
@@ -1,15 +1,14 @@
 from functools import wraps
-from typing import Any, Dict, List
+from typing import Dict, List
 from uuid import UUID
-from datetime import datetime
 
+from mhq.store.models.code.enums import TeamReposDeploymentType
 from flask import request
 from stringcase import snakecase
 from voluptuous import Invalid
 from werkzeug.exceptions import BadRequest
-from mhq.utils.time import time_now
 from mhq.store.models.code.repository import TeamRepos
-from mhq.service.code.models.org_repo import RawOrgRepo
+from mhq.service.code.models.org_repo import RawTeamOrgRepo
 from mhq.store.models.code import WorkflowFilter, CodeProvider
 
 from mhq.service.workflows.workflow_filter import get_workflow_filter_processor
@@ -82,18 +81,24 @@ def coerce_workflow_filter(filter_data: str) -> WorkflowFilter:
     )
 
 
-def coerce_org_repo(repo: Dict[str, str]) -> RawOrgRepo:
-    return RawOrgRepo(
+def coerce_org_repo(repo: Dict[str, str]) -> RawTeamOrgRepo:
+    return RawTeamOrgRepo(
+        team_id=repo.get("team_id"),
         provider=CodeProvider(repo.get("provider")),
         name=repo.get("name"),
         org_name=repo.get("org"),
         slug=repo.get("slug"),
         idempotency_key=repo.get("idempotency_key"),
         default_branch=repo.get("default_branch"),
+        deployment_type=(
+            TeamReposDeploymentType(repo.get("deployment_type"))
+            if repo.get("deployment_type")
+            else TeamReposDeploymentType.PR_MERGE
+        ),
     )
 
 
-def coerce_org_repos(repos: List[Dict[str, str]]) -> List[RawOrgRepo]:
+def coerce_org_repos(repos: List[Dict[str, str]]) -> List[RawTeamOrgRepo]:
     return [coerce_org_repo(repo) for repo in repos]
 
 

--- a/backend/analytics_server/mhq/api/teams.py
+++ b/backend/analytics_server/mhq/api/teams.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from flask import Blueprint
 from typing import Any, Dict, List
 from voluptuous import Required, Schema, Optional, All, Coerce

--- a/backend/analytics_server/mhq/api/teams.py
+++ b/backend/analytics_server/mhq/api/teams.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 from voluptuous import Required, Schema, Optional, All, Coerce
 from werkzeug.exceptions import BadRequest
 from mhq.store.models.code.repository import OrgRepo, TeamRepos
-from mhq.service.code.models.org_repo import RawOrgRepo
+from mhq.service.code.models.org_repo import RawTeamOrgRepo
 from mhq.api.resources.code_resouces import (
     adapt_org_repo,
     adapt_team_repos,
@@ -116,14 +116,24 @@ def fetch_team_repos(team_id: str):
         }
     ),
 )
-def update_team_repos(team_id: str, repos: List[RawOrgRepo]):
+def update_team_repos(team_id: str, repos: List[RawTeamOrgRepo]):
 
     query_validator = get_query_validator()
     team: Team = query_validator.team_validator(team_id)
 
-    team_repos = get_repository_service().update_team_repos(team, repos)
+    repository_service = get_repository_service()
+    updated_org_repos = repository_service.update_team_repos(team, repos)
+    repo_id_team_repos_map: Dict[str, TeamRepos] = (
+        repository_service.get_repo_id_team_repos_map(team, updated_org_repos)
+    )
 
-    return [adapt_org_repo(repo) for repo in team_repos]
+    adapted_repos: List[Dict[str, Any]] = []
+    for repo in updated_org_repos:
+        team_repo = repo_id_team_repos_map[str(repo.id)]
+        adapted_repo = adapt_team_repo_and_org_repo(repo, team_repo)
+        adapted_repos.append(adapted_repo)
+
+    return adapted_repos
 
 
 @app.route("/teams/<team_id>/team_repos", methods={"PATCH"})

--- a/backend/analytics_server/mhq/service/code/models/org_repo.py
+++ b/backend/analytics_server/mhq/service/code/models/org_repo.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
 
-from mhq.store.models.code.enums import CodeProvider
+from mhq.store.models.code.enums import CodeProvider, TeamReposDeploymentType
 
 
 @dataclass
-class RawOrgRepo:
+class RawTeamOrgRepo:
+    team_id: str
     provider: CodeProvider
     name: str
     org_name: str
     slug: str
     idempotency_key: str
     default_branch: str
+    deployment_type: TeamReposDeploymentType

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from operator import and_
-from typing import Optional, List
+from typing import Dict, Optional, List
 
+from mhq.store.models.code.enums import TeamReposDeploymentType
+from mhq.service.code.models.org_repo import RawTeamOrgRepo
 from sqlalchemy import or_
 from sqlalchemy.orm import defer
 from mhq.store.models.core import Team
@@ -41,37 +43,26 @@ class CodeRepoService:
         return self.get_repos_by_ids([str(repo.id) for repo in org_repos])
 
     @rollback_on_exc
-    def update_team_repos(self, team: Team, org_repos: List[OrgRepo]):
-
-        existing_team_repos = self._db.session.query(TeamRepos).filter(
-            TeamRepos.team_id == team.id
+    def get_existing_team_repos(self, team: Team) -> List[TeamRepos]:
+        return (
+            self._db.session.query(TeamRepos).filter(TeamRepos.team_id == team.id).all()
         )
 
-        for team_repo in existing_team_repos:
-            team_repo.is_active = False
+    @rollback_on_exc
+    def get_team_repos_by_repo_id_for_team(
+        self, team_id: str, repo_ids: List[str]
+    ) -> List[TeamRepos]:
+        return (
+            self._db.session.query(TeamRepos)
+            .filter(TeamRepos.team_id == team_id, TeamRepos.org_repo_id.in_(repo_ids))
+            .all()
+        )
 
-        repo_id_to_team_repos_map = {
-            str(team_repo.org_repo_id): team_repo for team_repo in existing_team_repos
-        }
-
-        updated_team_repos = []
-        for repo in org_repos:
-            team_repo = repo_id_to_team_repos_map.get(str(repo.id))
-            if team_repo:
-                team_repo.is_active = True
-            else:
-                team_repo = TeamRepos(
-                    team_id=team.id,
-                    org_repo_id=str(repo.id),
-                    prod_branches=(
-                        ["^" + repo.default_branch + "$"]
-                        if repo.default_branch
-                        else None
-                    ),
-                )
-
-            updated_team_repos.append(team_repo)
-
+    @rollback_on_exc
+    def update_team_repos(
+        self,
+        updated_team_repos: List[TeamRepos],
+    ):
         for team_repo in updated_team_repos:
             self._db.session.merge(team_repo)
 

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from operator import and_
-from typing import Dict, Optional, List
+from typing import Optional, List
 
-from mhq.store.models.code.enums import TeamReposDeploymentType
-from mhq.service.code.models.org_repo import RawTeamOrgRepo
 from sqlalchemy import or_
 from sqlalchemy.orm import defer
 from mhq.store.models.core import Team


### PR DESCRIPTION
## Purpose
This PR handles the updation of `deployment_type` field of `TeamRepos`. Frontend now sends `deployment_type` field in the request body. 

## Proposed changes (including videos or screenshots)
The `RawOrgRepo` dataclass has been extended to include `deployment_type` and the repo functions and service layer functions have been updated accordingly. 