### PR TITLE
Update `.gitattributes` to tell git to treat image files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,12 @@
 # Treat all text files without a CR (as we have Docker)
 * text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.gz binary
+*.zip binary
+*.ttf binary


### PR DESCRIPTION
## Proposed changes

This PR updates `.gitattributes` which instructs git to handle binary file differently. That means the line ending conversions won't occur for binary files. Without these git might warn/complain about these file.