### PR TITLE
Revert PR sync for gitlab

### DIFF
--- a/backend/analytics_server/mhq/service/code/sync/revert_pr_gitlab_sync.py
+++ b/backend/analytics_server/mhq/service/code/sync/revert_pr_gitlab_sync.py
@@ -52,7 +52,7 @@ class RevertPRsGitlabSyncHandler:
         """
 
         repo_ids: Set[str] = set()
-        repo_id_to_pr_merge_hash_to_id_map: Dict[str, Dict[str, str]] = {}
+        repo_id_to_pr_merge_hash_to_revert_pr_id_map: Dict[str, Dict[str, str]] = {}
         pr_merge_hash_match_strings: List[str] = []
 
         for pr in prs:
@@ -62,10 +62,10 @@ class RevertPRsGitlabSyncHandler:
             pr_merge_hash_match_strings.append(f"revert-{pr.merge_commit_sha[:8]}")
             repo_ids.add(str(pr.repo_id))
 
-            if str(pr.repo_id) not in repo_id_to_pr_merge_hash_to_id_map:
-                repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)] = {}
+            if str(pr.repo_id) not in repo_id_to_pr_merge_hash_to_revert_pr_id_map:
+                repo_id_to_pr_merge_hash_to_revert_pr_id_map[str(pr.repo_id)] = {}
 
-            repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)][
+            repo_id_to_pr_merge_hash_to_revert_pr_id_map[str(pr.repo_id)][
                 str(pr.merge_commit_sha[:8])
             ] = pr.id
 
@@ -85,13 +85,13 @@ class RevertPRsGitlabSyncHandler:
             if merge_commit_hash is None:
                 continue
 
-            repo_key_exists = repo_id_to_pr_merge_hash_to_id_map.get(
+            repo_key_exists = repo_id_to_pr_merge_hash_to_revert_pr_id_map.get(
                 str(rev_pr.repo_id)
             )
             if repo_key_exists is None:
                 continue
 
-            original_pr_id = repo_id_to_pr_merge_hash_to_id_map[
+            original_pr_id = repo_id_to_pr_merge_hash_to_revert_pr_id_map[
                 str(rev_pr.repo_id)
             ].get(merge_commit_hash)
             if original_pr_id is None:
@@ -118,7 +118,7 @@ class RevertPRsGitlabSyncHandler:
         """
         revert_pr_hashes: List[str] = []
         repo_ids: Set[str] = set()
-        repo_id_to_pr_merge_hash_to_id_map: Dict[str, Dict[str, str]] = {}
+        repo_id_to_pr_merge_hash_to_revert_pr_id_map: Dict[str, Dict[str, str]] = {}
 
         for pr in prs:
             revert_pr_merge_commit_hash = self.get_revert_merge_commit_hash(
@@ -130,10 +130,10 @@ class RevertPRsGitlabSyncHandler:
             revert_pr_hashes.append(revert_pr_merge_commit_hash)
             repo_ids.add(str(pr.repo_id))
 
-            if str(pr.repo_id) not in repo_id_to_pr_merge_hash_to_id_map:
-                repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)] = {}
+            if str(pr.repo_id) not in repo_id_to_pr_merge_hash_to_revert_pr_id_map:
+                repo_id_to_pr_merge_hash_to_revert_pr_id_map[str(pr.repo_id)] = {}
 
-            repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)][
+            repo_id_to_pr_merge_hash_to_revert_pr_id_map[str(pr.repo_id)][
                 str(revert_pr_merge_commit_hash)
             ] = pr.id
 
@@ -148,14 +148,14 @@ class RevertPRsGitlabSyncHandler:
 
         revert_pr_mappings: List[PullRequestRevertPRMapping] = []
         for rev_pr in reverted_prs:
-            repo_key_exists = repo_id_to_pr_merge_hash_to_id_map.get(
+            repo_key_exists = repo_id_to_pr_merge_hash_to_revert_pr_id_map.get(
                 str(rev_pr.repo_id)
             )
             if repo_key_exists is None:
                 continue
 
             commit_hash = rev_pr.merge_commit_sha[:8]
-            original_pr_id = repo_id_to_pr_merge_hash_to_id_map[
+            original_pr_id = repo_id_to_pr_merge_hash_to_revert_pr_id_map[
                 str(rev_pr.repo_id)
             ].get(commit_hash)
             if original_pr_id is None:

--- a/backend/analytics_server/mhq/service/code/sync/revert_pr_gitlab_sync.py
+++ b/backend/analytics_server/mhq/service/code/sync/revert_pr_gitlab_sync.py
@@ -1,0 +1,192 @@
+import re
+from datetime import datetime
+from typing import Dict, List, Optional, Set
+from mhq.store.models.code.enums import (
+    PullRequestRevertPRMappingActorType,
+    PullRequestState,
+)
+from mhq.store.models.code.pull_requests import PullRequest, PullRequestRevertPRMapping
+from mhq.store.repos.code import CodeRepoService
+
+
+class RevertPRsGitlabSyncHandler:
+    def __init__(self, code_repo_service: CodeRepoService):
+        self.code_repo_service = code_repo_service
+
+    def __call__(self, *args, **kwargs):
+        return self.process_revert_prs(*args, **kwargs)
+
+    def process_revert_prs(
+        self, prs: List[PullRequest]
+    ) -> List[PullRequestRevertPRMapping]:
+        revert_prs: List[PullRequest] = []
+        original_prs: List[PullRequest] = []
+
+        for pr in prs:
+            pr_merge_commit_sha = (
+                self.get_revert_merge_commit_hash(pr.head_branch)
+                if pr.head_branch
+                else None
+            )
+            if pr_merge_commit_sha is None:
+                original_prs.append(pr)
+            else:
+                revert_prs.append(pr)
+
+        mappings_of_revert_prs = self._get_revert_pr_mapping_for_revert_prs(revert_prs)
+        mappings_of_original_prs = self._get_revert_pr_mapping_for_original_prs(
+            original_prs
+        )
+        revert_pr_mappings = set(mappings_of_original_prs + mappings_of_revert_prs)
+
+        return list(revert_pr_mappings)
+
+    def _get_revert_pr_mapping_for_original_prs(
+        self, prs: List[PullRequest]
+    ) -> List[PullRequestRevertPRMapping]:
+        """
+        This function takes a list of PRs and for each PR it tries to
+        find if that pr has been reverted and by which PR. It is done
+        by taking repo_id and the merge commit hash and searching for
+        the string 'revert-[merge-commit-hash]' in the head branch.
+        """
+
+        repo_ids: Set[str] = set()
+        repo_id_to_pr_merge_hash_to_id_map: Dict[str, Dict[str, str]] = {}
+        pr_merge_hash_match_strings: List[str] = []
+
+        for pr in prs:
+            if pr.state != PullRequestState.MERGED:
+                continue
+
+            pr_merge_hash_match_strings.append(f"revert-{pr.merge_commit_sha[:8]}")
+            repo_ids.add(str(pr.repo_id))
+
+            if str(pr.repo_id) not in repo_id_to_pr_merge_hash_to_id_map:
+                repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)] = {}
+
+            repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)][
+                str(pr.merge_commit_sha[:8])
+            ] = pr.id
+
+        if len(pr_merge_hash_match_strings) == 0:
+            return []
+
+        revert_prs: List[PullRequest] = (
+            self.code_repo_service.get_prs_by_head_branch_match_strings(
+                list(repo_ids), pr_merge_hash_match_strings
+            )
+        )
+
+        revert_pr_mappings: List[PullRequestRevertPRMapping] = []
+
+        for rev_pr in revert_prs:
+            merge_commit_hash = self.get_revert_merge_commit_hash(rev_pr.head_branch)
+            if merge_commit_hash is None:
+                continue
+
+            repo_key_exists = repo_id_to_pr_merge_hash_to_id_map.get(
+                str(rev_pr.repo_id)
+            )
+            if repo_key_exists is None:
+                continue
+
+            original_pr_id = repo_id_to_pr_merge_hash_to_id_map[
+                str(rev_pr.repo_id)
+            ].get(merge_commit_hash)
+            if original_pr_id is None:
+                continue
+
+            revert_pr_mp = PullRequestRevertPRMapping(
+                pr_id=rev_pr.id,
+                actor_type=PullRequestRevertPRMappingActorType.SYSTEM,
+                actor=None,
+                reverted_pr=original_pr_id,
+                updated_at=datetime.now(),
+            )
+            revert_pr_mappings.append(revert_pr_mp)
+
+        return revert_pr_mappings
+
+    def _get_revert_pr_mapping_for_revert_prs(
+        self, prs: List[PullRequest]
+    ) -> List[PullRequestRevertPRMapping]:
+        """
+        This function takes a list of PRs and for each PR it tries to
+        find if that pr is a revert PR and for that revert PR it tries
+        to find the original which was reverted and create a mapping.
+        """
+        revert_pr_hashes: List[str] = []
+        repo_ids: Set[str] = set()
+        repo_id_to_pr_merge_hash_to_id_map: Dict[str, Dict[str, str]] = {}
+
+        for pr in prs:
+            revert_pr_merge_commit_hash = self.get_revert_merge_commit_hash(
+                pr.head_branch
+            )
+            if revert_pr_merge_commit_hash is None:
+                continue
+
+            revert_pr_hashes.append(revert_pr_merge_commit_hash)
+            repo_ids.add(str(pr.repo_id))
+
+            if str(pr.repo_id) not in repo_id_to_pr_merge_hash_to_id_map:
+                repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)] = {}
+
+            repo_id_to_pr_merge_hash_to_id_map[str(pr.repo_id)][
+                str(revert_pr_merge_commit_hash)
+            ] = pr.id
+
+            if len(revert_pr_hashes) == 0:
+                return []
+
+        reverted_prs: List[PullRequest] = (
+            self.code_repo_service.get_reverted_prs_by_merge_commit_hash(
+                list(repo_ids), revert_pr_hashes
+            )
+        )
+
+        revert_pr_mappings: List[PullRequestRevertPRMapping] = []
+        for rev_pr in reverted_prs:
+            repo_key_exists = repo_id_to_pr_merge_hash_to_id_map.get(
+                str(rev_pr.repo_id)
+            )
+            if repo_key_exists is None:
+                continue
+
+            commit_hash = rev_pr.merge_commit_sha[:8]
+            original_pr_id = repo_id_to_pr_merge_hash_to_id_map[
+                str(rev_pr.repo_id)
+            ].get(commit_hash)
+            if original_pr_id is None:
+                continue
+
+            revert_pr_mp = PullRequestRevertPRMapping(
+                pr_id=original_pr_id,
+                actor_type=PullRequestRevertPRMappingActorType.SYSTEM,
+                actor=None,
+                reverted_pr=rev_pr.id,
+                updated_at=datetime.now(),
+            )
+            revert_pr_mappings.append(revert_pr_mp)
+
+        return revert_pr_mappings
+
+    def get_revert_merge_commit_hash(self, head_branch: str) -> Optional[str]:
+        """
+        Function to match the regex pattern "revert-pr-[merge_commit_hash]" and
+        return the merge_commit hash for Gitlab. The commit hash will be at least
+        8 characters and at most 40 characters long
+        """
+        pattern = r"^revert-([a-fA-F0-9]{8})$"
+
+        matches = re.findall(pattern, head_branch)
+
+        if matches:
+            return matches[-1]
+        else:
+            return None
+
+
+def get_revert_prs_gitlab_sync_handler() -> RevertPRsGitlabSyncHandler:
+    return RevertPRsGitlabSyncHandler(CodeRepoService())

--- a/backend/analytics_server/tests/service/code/sync/test_revert_pr_gitlab_sync.py
+++ b/backend/analytics_server/tests/service/code/sync/test_revert_pr_gitlab_sync.py
@@ -1,0 +1,265 @@
+from datetime import datetime
+from mhq.store.models.code.enums import PullRequestState
+from mhq.store.models.code.pull_requests import PullRequest, PullRequestRevertPRMapping
+from mhq.service.code.sync.revert_pr_gitlab_sync import RevertPRsGitlabSyncHandler
+
+
+def test_get_revert_merge_commit_hash():
+    class FakeCodeRepoService:
+        pass
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+
+    assert handler.get_revert_merge_commit_hash("revert-12345678") == "12345678"
+    assert handler.get_revert_merge_commit_hash("revert-abcdef12") == "abcdef12"
+    assert handler.get_revert_merge_commit_hash("not-a-revert-branch") is None
+    assert handler.get_revert_merge_commit_hash("revert-123") is None
+    assert handler.get_revert_merge_commit_hash("revert-1234567890abcdef") == None
+
+
+def test_process_revert_prs_empty_list():
+    class FakeCodeRepoService:
+        def get_reverted_prs_by_merge_commit_hash(self, repo_ids, merge_commit_hashes):
+            return []
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    result = handler.process_revert_prs([])
+    assert result == []
+
+
+def test_process_revert_prs_no_revert_prs():
+    class FakeCodeRepoService:
+        def get_prs_by_head_branch_match_strings(self, repo_ids, match_strings):
+            return []
+
+        def get_reverted_prs_by_merge_commit_hash(self, repo_ids, merge_commit_hashes):
+            return []
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    prs = [
+        PullRequest(
+            id="1",
+            repo_id="repo1",
+            head_branch="feature-branch",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="abcde11234567890",
+        ),
+        PullRequest(
+            id="2",
+            repo_id="repo1",
+            head_branch="another-branch",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="1234567890abcdef",
+        ),
+    ]
+
+    result = handler.process_revert_prs(prs)
+    assert result == []
+
+
+def test_process_revert_prs_with_revert_prs():
+    class FakeCodeRepoService:
+        def get_reverted_prs_by_merge_commit_hash(self, repo_ids, merge_commit_hashes):
+            return [
+                PullRequest(
+                    id="2",
+                    repo_id="repo1",
+                    head_branch="feature-branch",
+                    state=PullRequestState.MERGED,
+                    merge_commit_sha="abcdef1234567890",
+                )
+            ]
+
+        def get_prs_by_head_branch_match_strings(self, repo_ids, match_strings):
+            return []
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    prs = [
+        PullRequest(
+            id="1",
+            repo_id="repo1",
+            head_branch="revert-abcdef12",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="1234567890abcdef",
+        ),
+        PullRequest(
+            id="2",
+            repo_id="repo1",
+            head_branch="feature-branch",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="abcdef1234567890",
+        ),
+    ]
+
+    result = handler.process_revert_prs(prs)
+    assert len(result) == 1
+    assert isinstance(result[0], PullRequestRevertPRMapping)
+    assert result[0].pr_id == "1"
+    assert result[0].reverted_pr == "2"
+
+
+def test_process_revert_prs_with_original_pr():
+    class FakeCodeRepoService:
+        def get_reverted_prs_by_merge_commit_hash(self, repo_ids, merge_commit_hashes):
+            return []
+
+        def get_prs_by_head_branch_match_strings(self, repo_ids, match_strings):
+            return [
+                PullRequest(
+                    id="1",
+                    repo_id="repo1",
+                    head_branch="revert-abcdef12",
+                    state=PullRequestState.MERGED,
+                    merge_commit_sha="1234567890abcdef",
+                )
+            ]
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    prs = [
+        PullRequest(
+            id="1",
+            repo_id="repo1",
+            head_branch="revert-abcdef12",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="1234567890abcdef",
+        ),
+        PullRequest(
+            id="2",
+            repo_id="repo1",
+            head_branch="feature-branch",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="abcdef1234567890",
+        ),
+    ]
+
+    result = handler.process_revert_prs(prs)
+    assert len(result) == 1
+    assert isinstance(result[0], PullRequestRevertPRMapping)
+    assert result[0].pr_id == "1"
+    assert result[0].reverted_pr == "2"
+
+
+def test_process_revert_prs_datetime():
+    class FakeCodeRepoService:
+        def get_reverted_prs_by_merge_commit_hash(self, repo_ids, merge_commit_hashes):
+            return [
+                PullRequest(
+                    id="2", repo_id="repo1", merge_commit_sha="abcdef1234567890"
+                )
+            ]
+
+        def get_prs_by_head_branch_match_strings(self, repo_ids, match_strings):
+            return []
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    prs = [
+        PullRequest(
+            id="1",
+            repo_id="repo1",
+            head_branch="revert-abcdef12",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="1234567890abcdef",
+        ),
+    ]
+
+    result = handler.process_revert_prs(prs)
+    assert len(result) == 1
+    assert isinstance(result[0].updated_at, datetime)
+
+
+def test_get_revert_pr_mapping_for_original_prs_non_merged():
+    class FakeCodeRepoService:
+        pass
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    prs = [
+        PullRequest(
+            id="1",
+            repo_id="repo1",
+            head_branch="feature-branch",
+            state=PullRequestState.OPEN,
+            merge_commit_sha="abcdef1234567890",
+        ),
+    ]
+
+    result = handler._get_revert_pr_mapping_for_original_prs(prs)
+    assert result == []
+
+
+def test_process_revert_prs_with_no_mappings_found():
+    class FakeCodeRepoService:
+        def get_reverted_prs_by_merge_commit_hash(self, repo_ids, merge_commit_hashes):
+            return []
+
+        def get_prs_by_head_branch_match_strings(self, repo_ids, match_strings):
+            return []
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    prs = [
+        PullRequest(
+            id="1",
+            repo_id="repo1",
+            head_branch="revert-abcdef12",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="1234567890abcdef",
+        ),
+        PullRequest(
+            id="2",
+            repo_id="repo1",
+            head_branch="feature-branch",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="abcdef1234567890",
+        ),
+    ]
+
+    result = handler.process_revert_prs(prs)
+    assert result == []
+
+
+def test_process_revert_prs_with_duplicate_mappings():
+    class FakeCodeRepoService:
+        def get_reverted_prs_by_merge_commit_hash(self, repo_ids, merge_commit_hashes):
+            return [
+                PullRequest(
+                    id="2",
+                    repo_id="repo1",
+                    head_branch="feature-branch",
+                    state=PullRequestState.MERGED,
+                    merge_commit_sha="abcdef1234567890",
+                )
+            ]
+
+        def get_prs_by_head_branch_match_strings(self, repo_ids, match_strings):
+            return [
+                PullRequest(
+                    id="1",
+                    repo_id="repo1",
+                    head_branch="revert-abcdef12",
+                    state=PullRequestState.MERGED,
+                    merge_commit_sha="1234567890abcdef",
+                )
+            ]
+
+    handler = RevertPRsGitlabSyncHandler(FakeCodeRepoService())
+    prs = [
+        PullRequest(
+            id="1",
+            repo_id="repo1",
+            head_branch="revert-abcdef12",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="1234567890abcdef",
+        ),
+        PullRequest(
+            id="2",
+            repo_id="repo1",
+            head_branch="feature-branch",
+            state=PullRequestState.MERGED,
+            merge_commit_sha="abcdef1234567890",
+        ),
+    ]
+
+    result = handler.process_revert_prs(prs)
+    assert len(result) == 1
+    assert isinstance(result[0], PullRequestRevertPRMapping)
+    assert result[0].pr_id == "1"
+    assert result[0].reverted_pr == "2"


### PR DESCRIPTION
## Linked Issue(s) 
Closes #460 

## Proposed Changes
A service module to sync gitlab revert prs. This will be called by the gitlab sync service which will be later implemented. Tests are also written for the same service.