### PR TITLE
Gitlab repo sync ETL handler

### DIFF
--- a/backend/analytics_server/mhq/exapi/gitlab.py
+++ b/backend/analytics_server/mhq/exapi/gitlab.py
@@ -18,6 +18,20 @@ class GitlabApiService:
         self.base_url = f"https://{domain}/api/v4"
         self.headers = {"Authorization": f"Bearer {self._token}"}
 
+    def check_pat(self) -> bool:
+        """
+        Checks if PAT is Valid
+        :returns:
+        :raises HTTPError: If the request fails and status code is not 200
+        """
+        url = f"{self.base_url}/user"
+        try:
+            response = requests.get(url, headers=self.headers)
+        except Exception as e:
+            raise Exception(f"Error in PAT validation, Error: {e.data}")
+
+        return response.status_code == 200
+
     def _handle_error(self, response):
         if response.status_code != 200:
             error = response.json().get("error", "")

--- a/backend/analytics_server/mhq/service/code/integration.py
+++ b/backend/analytics_server/mhq/service/code/integration.py
@@ -5,6 +5,7 @@ from mhq.store.repos.core import CoreRepoService
 
 CODE_INTEGRATION_BUCKET = [
     UserIdentityProvider.GITHUB.value,
+    UserIdentityProvider.GITLAB.value,
 ]
 
 

--- a/backend/analytics_server/mhq/service/code/sync/etl_code_factory.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_code_factory.py
@@ -1,3 +1,4 @@
+from mhq.service.code.sync.etl_gitlab_handler import get_gitlab_etl_handler
 from mhq.service.code.sync.etl_github_handler import get_github_etl_handler
 from mhq.service.code.sync.etl_provider_handler import CodeProviderETLHandler
 from mhq.store.models.code import CodeProvider
@@ -10,4 +11,8 @@ class CodeETLFactory:
     def __call__(self, provider: str) -> CodeProviderETLHandler:
         if provider == CodeProvider.GITHUB.value:
             return get_github_etl_handler(self.org_id)
+
+        if provider == CodeProvider.GITLAB.value:
+            return get_gitlab_etl_handler(self.org_id)
+
         raise NotImplementedError(f"Unknown provider - {provider}")

--- a/backend/analytics_server/mhq/service/code/sync/etl_gitlab_handler.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_gitlab_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import List, Dict, Optional, Tuple, Set, Any
+from uuid import uuid4
 from mhq.utils.diffparser import parse_gitlab_diffs
 from mhq.exapi.models.gitlab import (
     GitlabCommit,
@@ -246,7 +247,7 @@ class GitlabETLHandler(CodeProviderETLHandler):
         pr_model: Optional[PullRequest],
         repo_id: str,
     ):
-        pr_id = pr_model.id if pr_model else uuid4_str()
+        pr_id = pr_model.id if pr_model else uuid4()
         return PullRequest(
             id=pr_id,
             number=pr.number,
@@ -342,7 +343,7 @@ class GitlabETLHandler(CodeProviderETLHandler):
                     data=review.data,
                     created_at=review.created_at,
                     idempotency_key=str(review.idempotency_key),
-                    org_repo_id=str(pr_model.repo_id),
+                    org_repo_id=pr_model.repo_id,
                     actor_username=review.actor_username,
                 )
             )

--- a/backend/analytics_server/mhq/service/code/sync/etl_gitlab_handler.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_gitlab_handler.py
@@ -1,0 +1,384 @@
+import asyncio
+from typing import List, Dict, Optional, Tuple, Set, Any
+from mhq.utils.diffparser import parse_gitlab_diffs
+from mhq.exapi.models.gitlab import (
+    GitlabCommit,
+    GitlabNote,
+    GitlabNoteType,
+    GitlabPR,
+    GitlabPRState,
+    GitlabRepo,
+)
+from mhq.store.models.code.enums import PullRequestEventState
+from mhq.utils.string import uuid4_str
+from mhq.service.code.sync.revert_pr_gitlab_sync import (
+    RevertPRsGitlabSyncHandler,
+    get_revert_prs_gitlab_sync_handler,
+)
+from mhq.exapi.gitlab import GitlabApiService
+from mhq.service.code.sync.etl_code_analytics import CodeETLAnalyticsService
+from mhq.service.code.sync.etl_provider_handler import CodeProviderETLHandler
+from mhq.store.models import UserIdentityProvider
+from mhq.store.models.code import (
+    OrgRepo,
+    Bookmark,
+    PullRequestState,
+    PullRequest,
+    PullRequestCommit,
+    PullRequestEvent,
+    PullRequestEventType,
+    PullRequestRevertPRMapping,
+    CodeProvider,
+)
+from mhq.store.repos.code import CodeRepoService
+from mhq.store.repos.core import CoreRepoService
+from mhq.utils.log import LOG
+from mhq.utils.time import dt_from_iso_time_string, time_now
+
+PR_PROCESSING_CHUNK_SIZE = 100
+
+
+class GitlabETLHandler(CodeProviderETLHandler):
+    def __init__(
+        self,
+        org_id: str,
+        gitlab_api_service: GitlabApiService,
+        code_repo_service: CodeRepoService,
+        code_etl_analytics_service: CodeETLAnalyticsService,
+        gitlab_revert_pr_sync_handler: RevertPRsGitlabSyncHandler,
+    ):
+        self.org_id: str = org_id
+        self._api: GitlabApiService = gitlab_api_service
+        self.code_repo_service: CodeRepoService = code_repo_service
+        self.code_etl_analytics_service: CodeETLAnalyticsService = (
+            code_etl_analytics_service
+        )
+        self.gitlab_revert_pr_sync_handler: RevertPRsGitlabSyncHandler = (
+            gitlab_revert_pr_sync_handler
+        )
+        self.provider: str = CodeProvider.GITLAB.value
+
+    def check_pat_validity(self) -> bool:
+        """
+        This method checks if the PAT is valid.
+        :returns: PAT details
+        :raises: Exception if PAT is invalid
+        """
+        is_valid = self._api.check_pat()
+        if not is_valid:
+            raise Exception("Gitlab Personal Access Token is invalid")
+        return is_valid
+
+    def get_org_repos(self, org_repos: List[OrgRepo]) -> List[OrgRepo]:
+        """
+        This method returns Gitlab repos for Org.
+        :param org_repos: List of OrgRepo objects
+        :returns: List of Gitlab repos as OrgRepo objects
+        """
+        gitlab_repos: List[GitlabRepo] = [
+            self._api.get_project(org_repo.idempotency_key) for org_repo in org_repos
+        ]
+
+        repo_idempotency_key_org_repo_map = {
+            org_repo.idempotency_key: org_repo for org_repo in org_repos
+        }
+
+        return [
+            self._process_gitlab_repo(
+                repo_idempotency_key_org_repo_map.get(str(gitlab_repo.idempotency_key)),
+                gitlab_repo,
+            )
+            for gitlab_repo in gitlab_repos
+            if repo_idempotency_key_org_repo_map.get(str(gitlab_repo.idempotency_key))
+        ]
+
+    def get_revert_prs_mapping(
+        self, prs: List[PullRequest]
+    ) -> List[PullRequestRevertPRMapping]:
+        return self.gitlab_revert_pr_sync_handler(prs)
+
+    def _process_gitlab_repo(
+        self, org_repo: OrgRepo, gitlab_repo: GitlabRepo
+    ) -> OrgRepo:
+        org_repo = OrgRepo(
+            id=org_repo.id,
+            org_id=self.org_id,
+            name=gitlab_repo.name,
+            provider=self.provider,
+            org_name=org_repo.org_name,
+            default_branch=gitlab_repo.default_branch,
+            language=str(gitlab_repo.languages),
+            contributors=self.get_repo_contributors(gitlab_repo),
+            idempotency_key=str(gitlab_repo.idempotency_key),
+            slug=gitlab_repo.name,
+            updated_at=time_now(),
+        )
+        return org_repo
+
+    def get_repo_pull_requests_data(
+        self, org_repo: OrgRepo, bookmark: Bookmark
+    ) -> Tuple[List[PullRequest], List[PullRequestCommit], List[PullRequestEvent]]:
+        """
+        This method returns all pull requests, their Commits and Events of a repo.
+        :param org_repo: OrgRepo object to get pull requests for
+        :param bookmark: Bookmark date to get all pull requests after this date
+        :return: Pull requests, their commits and events
+        """
+        gitlab_repo: GitlabRepo = self._api.get_project(org_repo.idempotency_key)
+        bookmark_time = dt_from_iso_time_string(bookmark.bookmark)
+        prs_to_process: List[Dict] = asyncio.run(
+            self._api.get_project_merge_requests(
+                gitlab_repo.idempotency_key, bookmark_time
+            )
+        )
+        filtered_prs: List[Dict] = []
+        for pr in prs_to_process:
+            if pr not in filtered_prs:
+                filtered_prs.append(pr)
+
+        filtered_prs = filtered_prs[::-1]
+        if not filtered_prs:
+            print("Nothing to process 🎉")
+            return [], [], []
+
+        pull_requests: List[PullRequest] = []
+        pr_commits: List[PullRequestCommit] = []
+        pr_events: List[PullRequestEvent] = []
+        prs_added: Set[int] = set()
+
+        for gitlab_pr in filtered_prs:
+            gitlab_pr = GitlabPR(gitlab_pr)
+            if gitlab_pr.number in prs_added:
+                continue
+
+            pr_model, event_models, pr_commit_models = self.process_pr(
+                str(org_repo.id), str(org_repo.idempotency_key), gitlab_pr
+            )
+            pull_requests.append(pr_model)
+            pr_events += event_models
+            pr_commits += pr_commit_models
+            prs_added.add(gitlab_pr.number)
+
+        return pull_requests, pr_commits, pr_events
+
+    def process_pr(
+        self, repo_id: str, repo_idempotency_key: str, pr: GitlabPR
+    ) -> Tuple[PullRequest, List[PullRequestEvent], List[PullRequestCommit]]:
+        pr_model: Optional[PullRequest] = self.code_repo_service.get_repo_pr_by_number(
+            repo_id, pr.number
+        )
+        pr_event_model_list: List[PullRequestEvent] = (
+            self.code_repo_service.get_pr_events(pr_model)
+        )
+        pr_commits_model_list: List = []
+        reviews: List[GitlabNote] = self._api.get_merge_request_notes(
+            repo_idempotency_key, pr.number
+        )
+
+        pr_model: PullRequest = GitlabETLHandler._to_pr_model(pr, pr_model, repo_id)
+        pr_events_models: List[PullRequestEvent] = GitlabETLHandler._to_pr_events(
+            reviews, pr_model, pr_event_model_list
+        )
+
+        if pr_model.state == PullRequestState.MERGED:
+            commits = self._api.get_merge_request_commits(
+                repo_idempotency_key, pr.number
+            )
+            pr_commits_model_list: List[PullRequestCommit] = self._to_pr_commits(
+                commits, pr_model
+            )
+
+            additions, deletions, files_changed = self.process_pr_code_stats(
+                repo_idempotency_key, pr_model
+            )
+            commits_count = len(pr_commits_model_list)
+
+            pr_model.meta = {
+                "code_stats": dict(
+                    commits=commits_count,
+                    additions=additions,
+                    deletions=deletions,
+                    changed_files=files_changed,
+                    comments=None,
+                ),
+                "user_profile": dict(username=pr_model.author),
+            }
+
+        pr_model = self.code_etl_analytics_service.create_pr_metrics(
+            pr_model, pr_events_models, pr_commits_model_list
+        )
+
+        return pr_model, pr_events_models, pr_commits_model_list
+
+    def process_pr_code_stats(
+        self,
+        repo_idempotency_key: str,
+        pr_model: PullRequest,
+    ) -> Tuple[int, int, int]:
+        pr_number = pr_model.number
+        response = self._api.get_merge_request_diff(repo_idempotency_key, pr_number)
+        diffs = list(map(lambda x: x.get("diff"), response))
+
+        additions, deletions, files_changed = parse_gitlab_diffs(diffs)
+        return additions, deletions, files_changed
+
+    def get_repo_contributors(self, gitlab_repo: GitlabRepo) -> Dict[str, Any]:
+        project_contributors: List[Dict] = self._api.get_project_contributors(
+            gitlab_repo.idempotency_key
+        )
+
+        contributors = [
+            [
+                contributor.get("email"),
+                contributor.get("commits", 0),
+            ]
+            for contributor in project_contributors
+            if contributor.get("email") is not None
+        ]
+        contributors_map = {
+            "contributions": contributors,
+        }
+        return contributors_map
+
+    @staticmethod
+    def _to_pr_model(
+        pr: GitlabPR,
+        pr_model: Optional[PullRequest],
+        repo_id: str,
+    ):
+        pr_id = pr_model.id if pr_model else uuid4_str()
+        return PullRequest(
+            id=pr_id,
+            number=pr.number,
+            title=pr.title,
+            url=pr.url,
+            author=pr.author,
+            state=GitlabETLHandler.process_pr_state(pr),
+            base_branch=pr.base_branch,
+            head_branch=pr.head_branch,
+            data=pr.data,
+            created_at=pr.created_at,
+            updated_at=pr.updated_at,
+            state_changed_at=pr.merged_at or pr.closed_at or pr.updated_at,
+            repo_id=repo_id,
+            requested_reviews=[],
+            meta=dict(),
+            reviewers=pr.reviewers,
+            provider=UserIdentityProvider.GITLAB.value,
+            merge_commit_sha=pr.merge_commit_sha,
+        )
+
+    @staticmethod
+    def process_pr_state(pr: GitlabPR) -> PullRequestState:
+        state = pr.state
+        if state == GitlabPRState.OPENED:
+            return PullRequestState.OPEN
+
+        if state == GitlabPRState.CLOSED:
+            return PullRequestState.CLOSED
+
+        if state == GitlabPRState.MERGED:
+            return PullRequestState.MERGED
+
+        if state == GitlabPRState.LOCKED:
+            if pr.merged_at:
+                return PullRequestState.MERGED
+            if pr.closed_at:
+                return PullRequestState.CLOSED
+
+        return PullRequestState.OPEN.value
+
+    @staticmethod
+    def _to_pr_commits(
+        commits: List[GitlabCommit], pr_model: PullRequest
+    ) -> List[PullRequestCommit]:
+        pr_commits: List[PullRequestCommit] = []
+
+        for commit in commits:
+            pr_commits.append(
+                PullRequestCommit(
+                    hash=commit.hash,
+                    pull_request_id=pr_model.id,
+                    message=commit.message,
+                    url=commit.url,
+                    data=commit.data,
+                    author=commit.author_email,
+                    created_at=commit.created_at,
+                    org_repo_id=pr_model.repo_id,
+                )
+            )
+        return pr_commits
+
+    @staticmethod
+    def _get_merge_commit_sha(raw_data: Dict, state: PullRequestState) -> Optional[str]:
+        if state != PullRequestState.MERGED:
+            return None
+
+        merge_commit_sha = raw_data.get("merge_commit_sha")
+
+        return merge_commit_sha
+
+    @staticmethod
+    def _to_pr_events(
+        reviews: List[GitlabNote],
+        pr_model: PullRequest,
+        pr_events_model: List[PullRequestEvent],
+    ) -> List[PullRequestEvent]:
+        pr_events: List[PullRequestEvent] = []
+        pr_review_id_map = {
+            event.idempotency_key: event.id for event in pr_events_model
+        }
+
+        for review in reviews:
+            if review.state == GitlabNoteType.UPDATED:
+                continue
+
+            review.data["state"] = GitlabETLHandler._get_event_state(review)
+            pr_events.append(
+                PullRequestEvent(
+                    id=pr_review_id_map.get(str(review.idempotency_key), uuid4_str()),
+                    pull_request_id=str(pr_model.id),
+                    type=PullRequestEventType.REVIEW.value,
+                    data=review.data,
+                    created_at=review.created_at,
+                    idempotency_key=str(review.idempotency_key),
+                    org_repo_id=str(pr_model.repo_id),
+                    actor_username=review.actor_username,
+                )
+            )
+
+        return pr_events
+
+    @staticmethod
+    def _get_event_state(event: GitlabNote):
+        if event.state == GitlabNoteType.CHANGES_REQUESTED:
+            return PullRequestEventState.CHANGES_REQUESTED.value
+        elif event.state == GitlabNoteType.APPROVED:
+            return PullRequestEventState.APPROVED.value
+        elif event.state == GitlabNoteType.COMMENTED:
+            return PullRequestEventState.COMMENTED.value
+        return None
+
+
+def get_gitlab_etl_handler(org_id: str) -> GitlabETLHandler:
+    def _get_custom_gitlab_domain() -> str:
+        pass
+
+    def _get_access_token():
+        core_repo_service = CoreRepoService()
+        access_token = core_repo_service.get_access_token(
+            org_id, UserIdentityProvider.GITLAB
+        )
+        if not access_token:
+            LOG.error(
+                f"Access token not found for org {org_id} and provider {UserIdentityProvider.GITLAB.value}"
+            )
+        return access_token
+
+    return GitlabETLHandler(
+        org_id,
+        GitlabApiService(_get_access_token()),
+        CodeRepoService(),
+        CodeETLAnalyticsService(),
+        get_revert_prs_gitlab_sync_handler(),
+    )

--- a/backend/analytics_server/mhq/service/incidents/sync/etl_incidents_factory.py
+++ b/backend/analytics_server/mhq/service/incidents/sync/etl_incidents_factory.py
@@ -12,4 +12,8 @@ class IncidentsETLFactory:
     def __call__(self, provider: str) -> IncidentsProviderETLHandler:
         if provider == IncidentProvider.GITHUB.value:
             return get_incidents_sync_etl_handler(self.org_id)
+
+        if provider == IncidentProvider.GITLAB.value:
+            return get_incidents_sync_etl_handler(self.org_id)
+
         raise NotImplementedError(f"Unknown provider - {provider}")

--- a/backend/analytics_server/mhq/store/models/code/enums.py
+++ b/backend/analytics_server/mhq/store/models/code/enums.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class CodeProvider(Enum):
     GITHUB = "github"
+    GITLAB = "gitlab"
 
 
 class BookmarkType(Enum):

--- a/backend/analytics_server/mhq/store/models/incidents/enums.py
+++ b/backend/analytics_server/mhq/store/models/incidents/enums.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class IncidentProvider(Enum):
     GITHUB = "github"
+    GITLAB = "gitlab"
 
 
 class IncidentSource(Enum):

--- a/backend/analytics_server/mhq/store/models/integrations/enums.py
+++ b/backend/analytics_server/mhq/store/models/integrations/enums.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class UserIdentityProvider(Enum):
     GITHUB = "github"
+    GITLAB = "gitlab"
 
     @classmethod
     def get_enum(self, provider: str):

--- a/backend/analytics_server/mhq/utils/diffparser.py
+++ b/backend/analytics_server/mhq/utils/diffparser.py
@@ -1,0 +1,24 @@
+import re
+
+
+def _parse_gitlab_diff(text):
+    line_range_match = re.search(
+        r"^@@ -(\d+),(\d+) \+(\d+),(\d+) @@$", text, flags=re.MULTILINE
+    )
+    if line_range_match:
+        deletion_lines = int(line_range_match.group(2))
+        addition_lines = int(line_range_match.group(4))
+    else:
+        deletion_lines = 0
+        addition_lines = 0
+    return addition_lines, deletion_lines
+
+
+def parse_gitlab_diffs(texts):
+    additions = 0
+    deletions = 0
+    for text in texts:
+        diff_additions, diff_deletions = _parse_gitlab_diff(text[:50])
+        additions += diff_additions
+        deletions += diff_deletions
+    return additions, deletions, len(texts)

--- a/backend/analytics_server/mhq/utils/time.py
+++ b/backend/analytics_server/mhq/utils/time.py
@@ -268,3 +268,10 @@ def fill_missing_week_buckets(
         curr_day = curr_day + timedelta(days=7)
 
     return sort_dict_by_datetime_keys(week_start_to_object_map_with_weeks_in_interval)
+
+
+def dt_from_iso_time_string(j_str_dt) -> Optional[datetime]:
+    if not j_str_dt:
+        return None
+    dt_without_timezone = datetime.strptime(j_str_dt, "%Y-%m-%dT%H:%M:%S.%f%z")
+    return dt_without_timezone.astimezone(pytz.UTC)

--- a/backend/analytics_server/tests/factories/models/exapi/gitlab.py
+++ b/backend/analytics_server/tests/factories/models/exapi/gitlab.py
@@ -1,0 +1,73 @@
+from typing import Dict
+from mhq.exapi.models.gitlab import GitlabCommit, GitlabNote, GitlabPR, GitlabPRState
+from mhq.utils.time import time_now
+from datetime import datetime
+
+
+def get_gitlab_pull_request(
+    number: int = 1,
+    merged_at: datetime = time_now(),
+    closed_at: datetime = time_now(),
+    title: str = "random_title",
+    html_url: str = None,
+    created_at: datetime = time_now(),
+    updated_at: datetime = time_now(),
+    base_ref: str = "main",
+    head_ref: str = "feature",
+    merge_commit_sha: str = "123456",
+    author: str = "gitlab_user",
+    state: str = GitlabPRState.MERGED.value,
+) -> GitlabPR:
+    return GitlabPR(
+        {
+            "iid": number,
+            "title": title,
+            "web_url": html_url,
+            "author": {"username": author},
+            "state": state,
+            "source_branch": head_ref,
+            "target_branch": base_ref,
+            "created_at": created_at.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            "closed_at": closed_at.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            "updated_at": updated_at.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            "merged_at": merged_at.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            "merge_commit_sha": merge_commit_sha,
+            "reviewers": [],
+            "merged_by": (
+                {"username": author} if state == GitlabPRState.MERGED.value else None
+            ),
+        }
+    )
+
+
+def get_gitlab_pull_request_review(
+    idempotency_key: str = "123456",
+    created_at: datetime = time_now(),
+    actor_username: str = "abc",
+) -> GitlabNote:
+
+    return GitlabNote(
+        {
+            "id": idempotency_key,
+            "created_at": created_at.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            "author": {"username": actor_username},
+        }
+    )
+
+
+def get_gitlab_commit(
+    message: str = None,
+    url: str = None,
+    sha: str = "random_hash",
+    author_login: str = "gitlab_author",
+    created_at: datetime = time_now(),
+) -> GitlabCommit:
+    return GitlabCommit(
+        {
+            "message": message,
+            "web_url": url,
+            "id": sha,
+            "author_email": author_login,
+            "created_at": created_at.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+        }
+    )

--- a/backend/analytics_server/tests/service/code/sync/test_etl_gitlab_handler.py
+++ b/backend/analytics_server/tests/service/code/sync/test_etl_gitlab_handler.py
@@ -1,0 +1,298 @@
+from datetime import datetime
+import pytz
+from tests.factories.models.exapi.gitlab import (
+    get_gitlab_commit,
+    get_gitlab_pull_request_review,
+)
+from tests.factories.models.code import (
+    get_pull_request,
+    get_pull_request_commit,
+    get_pull_request_event,
+)
+from tests.factories.models.exapi.gitlab import get_gitlab_pull_request
+from tests.utilities import compare_objects_as_dicts
+from mhq.service.code.sync.etl_gitlab_handler import GitlabETLHandler
+from mhq.utils.string import uuid4_str
+from mhq.store.models.code import PullRequestState
+
+
+def test__to_pr_model_given_a_gitlab_pr_returns_new_pr_model():
+    repo_id = uuid4_str()
+    number = 123
+    merged_at = datetime(2022, 6, 29, 10, 53, 15, tzinfo=pytz.UTC)
+    head_branch = "feature"
+    base_branch = "main"
+    title = "Test PR"
+    merge_commit_sha = "abcdef1234567890"
+    author = "gitlab_user"
+
+    gitlab_pr = get_gitlab_pull_request(
+        number=number,
+        merged_at=merged_at,
+        head_ref=head_branch,
+        base_ref=base_branch,
+        title=title,
+        merge_commit_sha=merge_commit_sha,
+        author=author,
+    )
+    gitlab_etl_handler = GitlabETLHandler("org_id", None, None, None, None)
+
+    pr_model = gitlab_etl_handler._to_pr_model(
+        pr=gitlab_pr,
+        pr_model=None,
+        repo_id=repo_id,
+    )
+
+    expected_pr_model = get_pull_request(
+        repo_id=repo_id,
+        number=str(number),
+        author=author,
+        state=PullRequestState.MERGED,
+        title=title,
+        head_branch=head_branch,
+        base_branch=base_branch,
+        provider="gitlab",
+        requested_reviews=[],
+        data=gitlab_pr.data,
+        state_changed_at=merged_at,
+        meta={},
+        reviewers=[],
+        merge_commit_sha=merge_commit_sha,
+    )
+    assert (
+        compare_objects_as_dicts(
+            pr_model,
+            expected_pr_model,
+            [
+                "created_at",
+                "updated_at",
+                "reviewers",
+                "rework_time",
+                "first_commit_to_open",
+                "first_response_time",
+                "lead_time",
+                "merge_time",
+                "merge_to_deploy",
+                "cycle_time",
+                "id",
+            ],
+        )
+        is True
+    )
+
+
+def test__to_pr_model_given_a_gitlab_pr_and_db_pr_returns_updated_pr_model():
+    repo_id = uuid4_str()
+    number = 123
+    merged_at = datetime(2022, 6, 29, 10, 53, 15, tzinfo=pytz.UTC)
+    head_branch = "feature"
+    base_branch = "main"
+    title = "Test PR"
+    merge_commit_sha = "abcdef1234567890"
+    author = "gitlab_user"
+
+    gitlab_pr = get_gitlab_pull_request(
+        number=number,
+        merged_at=merged_at,
+        head_ref=head_branch,
+        base_ref=base_branch,
+        title=title,
+        merge_commit_sha=merge_commit_sha,
+        author=author,
+    )
+    gitlab_etl_handler = GitlabETLHandler("org_id", None, None, None, None)
+    given_pr_model = get_pull_request(
+        repo_id=repo_id,
+        number=str(number),
+        provider="gitlab",
+    )
+
+    pr_model = gitlab_etl_handler._to_pr_model(
+        pr=gitlab_pr,
+        pr_model=given_pr_model,
+        repo_id=repo_id,
+    )
+
+    expected_pr_model = get_pull_request(
+        id=given_pr_model.id,
+        repo_id=repo_id,
+        number=str(number),
+        author=author,
+        state=PullRequestState.MERGED,
+        title=title,
+        head_branch=head_branch,
+        base_branch=base_branch,
+        provider="gitlab",
+        requested_reviews=[],
+        data=gitlab_pr.data,
+        state_changed_at=merged_at,
+        meta={},
+        reviewers=[],
+        merge_commit_sha=merge_commit_sha,
+    )
+    assert (
+        compare_objects_as_dicts(
+            pr_model,
+            expected_pr_model,
+            [
+                "created_at",
+                "updated_at",
+                "reviewers",
+                "rework_time",
+                "first_commit_to_open",
+                "first_response_time",
+                "lead_time",
+                "merge_time",
+                "merge_to_deploy",
+                "cycle_time",
+                "data",
+            ],
+        )
+        is True
+    )
+
+
+def test__to_pr_events_given_an_empty_list_of_events_returns_an_empty_list():
+    pr_model = get_pull_request()
+    assert GitlabETLHandler._to_pr_events([], pr_model, []) == []
+
+
+def test__to_pr_events_given_a_list_of_only_new_events_returns_a_list_of_pr_events():
+    pr_model = get_pull_request()
+    event1 = get_gitlab_pull_request_review()
+    event2 = get_gitlab_pull_request_review()
+    events = [event1, event2]
+
+    pr_events = GitlabETLHandler._to_pr_events(events, pr_model, [])
+
+    expected_pr_events = [
+        get_pull_request_event(
+            pull_request_id=str(pr_model.id),
+            org_repo_id=pr_model.repo_id,
+            data=event1.data,
+            created_at=event1.created_at,
+            type="REVIEW",
+            idempotency_key=event1.idempotency_key,
+            reviewer=event1.actor_username,
+        ),
+        get_pull_request_event(
+            pull_request_id=str(pr_model.id),
+            org_repo_id=pr_model.repo_id,
+            data=event2.data,
+            created_at=event2.created_at,
+            type="REVIEW",
+            idempotency_key=event2.idempotency_key,
+            reviewer=event2.actor_username,
+        ),
+    ]
+
+    for event, expected_event in zip(pr_events, expected_pr_events):
+        assert compare_objects_as_dicts(event, expected_event, ["id"]) is True
+
+
+def test__to_pr_events_given_a_list_of_new_events_and_old_events_returns_a_list_of_pr_events():
+    pr_model = get_pull_request()
+    event1 = get_gitlab_pull_request_review()
+    event2 = get_gitlab_pull_request_review()
+    events = [event1, event2]
+
+    old_event = get_pull_request_event(
+        pull_request_id=str(pr_model.id),
+        org_repo_id=pr_model.repo_id,
+        data=event1.data,
+        created_at=event1.created_at,
+        type="REVIEW",
+        idempotency_key=event1.idempotency_key,
+        reviewer=event1.actor_username,
+    )
+
+    pr_events = GitlabETLHandler._to_pr_events(events, pr_model, [old_event])
+
+    expected_pr_events = [
+        old_event,
+        get_pull_request_event(
+            pull_request_id=str(pr_model.id),
+            org_repo_id=pr_model.repo_id,
+            data=event2.data,
+            created_at=event2.created_at,
+            type="REVIEW",
+            idempotency_key=event2.idempotency_key,
+            reviewer=event2.actor_username,
+        ),
+    ]
+
+    for event, expected_event in zip(pr_events, expected_pr_events):
+        assert compare_objects_as_dicts(event, expected_event, ["id", "data"]) is True
+
+
+def test__to_pr_commits_given_an_empty_list_of_commits_returns_an_empty_list():
+    pr_model = get_pull_request()
+    gitlab_etl_handler = GitlabETLHandler("org_id", None, None, None, None)
+    assert gitlab_etl_handler._to_pr_commits([], pr_model) == []
+
+
+def test__to_pr_commits_given_a_list_of_commits_returns_a_list_of_pr_commits():
+    pr_model = get_pull_request()
+    common_url = "random_url"
+    common_message = "random_message"
+    sha1 = "123456789098765"
+    author1 = "author_abc"
+    commit1 = get_gitlab_commit(
+        sha=sha1,
+        author_login=author1,
+        url=common_url,
+        message=common_message,
+    )
+    sha2 = "987654321234567"
+    author2 = "author_xyz"
+    commit2 = get_gitlab_commit(
+        sha=sha2,
+        author_login=author2,
+        url=common_url,
+        message=common_message,
+    )
+    sha3 = "543216789098765"
+    author3 = "author_abc"
+    commit3 = get_gitlab_commit(
+        sha=sha3,
+        author_login=author3,
+        url=common_url,
+        message=common_message,
+    )
+
+    commits = [commit1, commit2, commit3]
+    gitlab_etl_handler = GitlabETLHandler("org_id", None, None, None, None)
+    pr_commits = gitlab_etl_handler._to_pr_commits(commits, pr_model)
+
+    expected_pr_commits = [
+        get_pull_request_commit(
+            pr_id=pr_model.id,
+            org_repo_id=pr_model.repo_id,
+            hash=sha1,
+            author=author1,
+            url=common_url,
+            message=common_message,
+            data=commit1.data,
+        ),
+        get_pull_request_commit(
+            pr_id=pr_model.id,
+            org_repo_id=pr_model.repo_id,
+            hash=sha2,
+            author=author2,
+            url=common_url,
+            message=common_message,
+            data=commit2.data,
+        ),
+        get_pull_request_commit(
+            pr_id=pr_model.id,
+            org_repo_id=pr_model.repo_id,
+            hash=sha3,
+            author=author3,
+            url=common_url,
+            message=common_message,
+            data=commit3.data,
+        ),
+    ]
+
+    for commit, expected_commit in zip(pr_commits, expected_pr_commits):
+        assert compare_objects_as_dicts(commit, expected_commit, ["created_at"]) is True


### PR DESCRIPTION
## Linked Issue(s) 
Closes #465 
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->


## Proposed changes 
This pr introduces a `GitlabETLHandler` service which exposes methods used by the sync layer to sync gitlab data. This includes repos data, prs_data and revert prs data used for incident mapping. The code has been tested through unit tests and manually running the sync after creating a `OrgRepo` data entry in the database manually. 