### PR TITLE
gitlab integration apis

### DIFF
--- a/backend/analytics_server/mhq/exapi/gitlab.py
+++ b/backend/analytics_server/mhq/exapi/gitlab.py
@@ -70,7 +70,7 @@ class GitlabApiService:
         return groups
 
     def get_group_projects(
-        self, group_id, page_size: int = 20, page: int = 1
+        self, group_id: str, page_size: int = 20, page: int = 1
     ) -> List[GitlabRepo]:
         url = f"{self.base_url}/groups/{group_id}/projects"
         params = {"page": page, "per_page": page_size}

--- a/backend/analytics_server/mhq/service/external_integrations_service.py
+++ b/backend/analytics_server/mhq/service/external_integrations_service.py
@@ -104,6 +104,7 @@ def get_external_integrations_service(
 ):
     def _get_custom_gitlab_domain() -> Optional[str]:
         DEFAULT_DOMAIN = "gitlab.com"
+
         core_repo_service = CoreRepoService()
         integrations = core_repo_service.get_org_integrations_for_names(
             org_id, [UserIdentityProvider.GITLAB.value]
@@ -133,6 +134,17 @@ def get_external_integrations_service(
             )
         return access_token
 
-    return ExternalIntegrationsService(
-        org_id, user_identity_provider, _get_access_token(), _get_custom_gitlab_domain()
-    )
+    if user_identity_provider == UserIdentityProvider.GITHUB:
+        return ExternalIntegrationsService(
+            org_id,
+            user_identity_provider,
+            _get_access_token(),
+        )
+
+    if user_identity_provider == UserIdentityProvider.GITLAB:
+        return ExternalIntegrationsService(
+            org_id,
+            user_identity_provider,
+            _get_access_token(),
+            _get_custom_gitlab_domain(),
+        )

--- a/backend/analytics_server/mhq/service/external_integrations_service.py
+++ b/backend/analytics_server/mhq/service/external_integrations_service.py
@@ -134,17 +134,13 @@ def get_external_integrations_service(
             )
         return access_token
 
-    if user_identity_provider == UserIdentityProvider.GITHUB:
-        return ExternalIntegrationsService(
-            org_id,
-            user_identity_provider,
-            _get_access_token(),
-        )
-
+    custom_domain_name = None
     if user_identity_provider == UserIdentityProvider.GITLAB:
-        return ExternalIntegrationsService(
-            org_id,
-            user_identity_provider,
-            _get_access_token(),
-            _get_custom_gitlab_domain(),
-        )
+        custom_domain_name = _get_custom_gitlab_domain()
+
+    return ExternalIntegrationsService(
+        org_id,
+        user_identity_provider,
+        _get_access_token(),
+        custom_domain_name,
+    )


### PR DESCRIPTION
## Linked Issue(s) 
Closes #467 


## Proposed changes (including videos or screenshots)
This PR introduces the following 3 apis:
- `/orgs/<org_id>/integrations/gitlab/groups` - Method: GET
- `/orgs/<org_id>/integrations/gitlab/user/repos` - Method: GET
- `/orgs/<org_id>/integrations/gitlab/groups/<group_id>/repos` - Method: GET
