### PR TITLE
Refactor deployment_type in TeamsCRUDProvider and update WorkflowSelector styles

### DIFF
--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -148,7 +148,7 @@ export const TeamsCRUDProvider: React.FC<{
     (_: SyntheticEvent<Element, Event>, value: BaseRepo[]) => {
       const reposWithDeploymentType = value.map((r) => ({
         ...r,
-        deployment_type: DeploymentSources.PR_MERGE
+        deployment_type: r.deployment_type ?? DeploymentSources.PR_MERGE
       }));
       depFn(selections.set, reposWithDeploymentType);
       depFn(teamRepoError.false);

--- a/web-server/src/components/WorkflowSelector.tsx
+++ b/web-server/src/components/WorkflowSelector.tsx
@@ -125,7 +125,12 @@ export const DeploymentWorkflowSelector: FC<{ repo: BaseRepo }> = ({
             'aria-labelledby': 'simple-menu',
             disablePadding: true,
             sx: {
-              padding: 0
+              padding: 0,
+              maxHeight: '350px',
+              overflowY: 'auto',
+              msOverflowStyle: 'none',
+              scrollbarWidth: 'none',
+              '&::-webkit-scrollbar': { display: 'none' }
             }
           }
         }}


### PR DESCRIPTION
This pull request includes two commits:

1. **Refactor: update deployment_type in TeamsCRUDProvider component**: This commit updates the `deployment_type` property in the `TeamsCRUDProvider` component to use the value from the `BaseRepo` object or fallback to `PR_MERGE` if the value is not provided.

2. **Chore: Update WorkflowSelector component styles for better user experience**: This commit updates the styles of the `WorkflowSelector` component to improve the user experience. It adds a maximum height, enables scrolling, and hides the scrollbar.

The changes in these commits aim to improve the functionality and user experience of the codebase.