### PR TITLE
Remove latest_github_commit field from version.ts and resources.ts

### DIFF
--- a/web-server/pages/api/internal/version.ts
+++ b/web-server/pages/api/internal/version.ts
@@ -18,7 +18,6 @@ type ProjectVersionInfo = {
 };
 
 type CheckNewVersionResponse = {
-  latest_github_commit: string;
   latest_docker_image: string;
   github_repo: string;
   current_github_commit: string;
@@ -153,7 +152,6 @@ async function checkNewImageRelease(): Promise<CheckNewVersionResponse> {
   const githubRepLink = `https://github.com/${githubOrgName}/${githubRepoName}`;
 
   return {
-    latest_github_commit: githubLatestCommit.sha,
     latest_docker_image: latestDockerImageLink,
     github_repo: githubRepLink,
     current_github_commit: versionInfo.merge_commit_sha,

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -1018,7 +1018,6 @@ export enum OnboardingStep {
 export type IntegrationsLinkedAtMap = Record<keyof IntegrationsMap, DateString>;
 
 export type ImageStatusApiResponse = {
-  latest_github_commit: string;
   latest_docker_image: string;
   is_update_available: boolean;
 };


### PR DESCRIPTION
This pull request removes the `latest_github_commit` field from the `version.ts` and `resources.ts` files. The field is no longer needed and has been removed to simplify the codebase.