### PR TITLE
Fixed postgres redis vice-versa logs display

### DIFF
--- a/cli/source/hooks/useLogsFromAllSources.tsx
+++ b/cli/source/hooks/useLogsFromAllSources.tsx
@@ -79,13 +79,13 @@ export const useLogsFromAllSources = () => {
         newLogs.push(...syncLogsRef.current.slice(-HIST_LIMIT));
         break;
       case LogSource.Postgres:
-        newLogs.push(...redisLogsRef.current.slice(-HIST_LIMIT));
+        newLogs.push(...pgLogsRef.current.slice(-HIST_LIMIT));
         break;
       case LogSource.InitDb:
         newLogs.push(...initDbLogsRef.current.slice(-HIST_LIMIT));
         break;
       case LogSource.Redis:
-        newLogs.push(...pgLogsRef.current.slice(-HIST_LIMIT));
+        newLogs.push(...redisLogsRef.current.slice(-HIST_LIMIT));
         break;
       case LogSource.Cron:
         newLogs.push(...cronLogsRef.current.slice(-HIST_LIMIT));


### PR DESCRIPTION
## Linked Issue(s) 

Closes #471 

## Proposed changes (including videos or screenshots)

CLI now displays correct logs for Postgres and Redis.
![Screenshot 2024-07-10 at 5 39 50 PM](https://github.com/middlewarehq/middleware/assets/90441742/fb0ac49c-c07d-4cd4-8ae7-ee6ec9029e42)
