### PR TITLE
Fixed CLI log switching between different Log Sources

### DIFF
--- a/cli/source/app.tsx
+++ b/cli/source/app.tsx
@@ -122,7 +122,7 @@ const CliUi = () => {
 
   useInput((input) => {
     if (appState === AppStates.DOCKER_READY) {
-      dispatch(appSlice.actions.setLogSource([]));
+      dispatch(appSlice.actions.setLogsStream([]));
       if (input === 'q') {
         dispatch(appSlice.actions.setLogSource(LogSource.WebServer));
       } else if (input === 'w') {

--- a/cli/source/app.tsx
+++ b/cli/source/app.tsx
@@ -122,6 +122,7 @@ const CliUi = () => {
 
   useInput((input) => {
     if (appState === AppStates.DOCKER_READY) {
+      dispatch(appSlice.actions.setLogSource([]));
       if (input === 'q') {
         dispatch(appSlice.actions.setLogSource(LogSource.WebServer));
       } else if (input === 'w') {


### PR DESCRIPTION
## Linked Issue(s) 

Closes #238 

## Proposed changes (including videos or screenshots)

User can now easily switch logs for different sources such as "API", "Web", "Redis" etc.