### PR TITLE
Add password type to Github Personal Access Token input field

### DIFF
--- a/web-server/src/components/PRTable/PullRequestsTable.tsx
+++ b/web-server/src/components/PRTable/PullRequestsTable.tsx
@@ -287,44 +287,29 @@ export const PullRequestsTable: FC<
                   )}
                   {enabledColumnsSet.has('author') && (
                     <TableCell sx={{ p: CELL_PAD }}>
-                      <LightTooltip
-                        arrow
-                        title={
-                          <Box>
-                            <Box>{`@${pr.author.username}`}</Box>
-                          </Box>
-                        }
+                      <FlexBox
+                        component={Link}
+                        href={getGHAvatar(pr.author.username)}
+                        target="_blank"
+                        fontWeight={500}
+                        alignCenter
                       >
-                        <Box
-                          display="flex"
-                          alignItems="center"
-                          gap={1}
-                          width="100%"
-                        >
-                          <Box
-                            component={Link}
-                            href={getGHAvatar(pr.author.username)}
-                            target="_blank"
-                            fontWeight={500}
-                            display="flex"
-                            alignItems="center"
-                          >
-                            <Avatar
-                              {...stringAvatar(
-                                (
-                                  pr.author.linked_user?.name ||
-                                  pr.author.username
-                                ).toUpperCase(),
-                                {
-                                  size: '2.4em',
-                                  boxShadow: `0 0 0 2px ${theme.colors.info.main}`
-                                }
-                              )}
-                              src={getGHAvatar(pr.author.username)}
-                            />
-                          </Box>
-                        </Box>
-                      </LightTooltip>
+                        <FlexBox title={`@${pr.author.username}`}>
+                          <Avatar
+                            {...stringAvatar(
+                              (
+                                pr.author.linked_user?.name ||
+                                pr.author.username
+                              ).toUpperCase(),
+                              {
+                                size: '2.4em',
+                                boxShadow: `0 0 0 2px ${theme.colors.info.main}`
+                              }
+                            )}
+                            src={getGHAvatar(pr.author.username)}
+                          />
+                        </FlexBox>
+                      </FlexBox>
                     </TableCell>
                   )}
                   {enabledColumnsSet.has('reviewers') && (
@@ -421,7 +406,9 @@ export const PullRequestsTable: FC<
 
 const PrReviewersCell: FC<{ pr: PR }> = ({ pr }) => {
   const theme = useTheme();
-  const sortedReviewers = [...pr.reviewers].sort((a, b) => a.username.localeCompare(b.username));
+  const sortedReviewers = [...pr.reviewers].sort((a, b) =>
+    a.username.localeCompare(b.username)
+  );
 
   return (
     <FlexBox

--- a/web-server/src/components/PRTable/PullRequestsTable.tsx
+++ b/web-server/src/components/PRTable/PullRequestsTable.tsx
@@ -411,14 +411,7 @@ const PrReviewersCell: FC<{ pr: PR }> = ({ pr }) => {
   );
 
   return (
-    <FlexBox
-      alignCenter
-      margin="auto"
-      gap={1}
-      width="100%"
-      flexWrap="wrap"
-      maxWidth="60px"
-    >
+    <FlexBox alignCenter gap={1} width="100%" flexWrap="wrap" maxWidth="60px">
       {sortedReviewers.map((reviewer) => (
         <FlexBox
           title={

--- a/web-server/src/content/Dashboards/useIntegrationHandlers.tsx
+++ b/web-server/src/content/Dashboards/useIntegrationHandlers.tsx
@@ -152,6 +152,7 @@ const ConfigureGithubModalBody: FC<{
               handleChange(e.currentTarget.value);
             }}
             label="Github Personal Access Token"
+            type="password"
           />
           <Line error tiny mt={1}>
             {showError.value}

--- a/web-server/src/hooks/useDoraMetricsGraph/index.tsx
+++ b/web-server/src/hooks/useDoraMetricsGraph/index.tsx
@@ -1,4 +1,4 @@
-import { lighten, rgbToHex } from '@mui/material';
+import { darken, lighten, rgbToHex } from '@mui/material';
 import { useMemo } from 'react';
 
 import { useSelector } from '@/store';
@@ -102,8 +102,8 @@ export const useDoraMetricsGraph = () => {
   const trendsSeriesMap = useMemo(
     () => ({
       firstCommitToPrTrends: {
-        id: `First Commit to Pr Time`,
-        color: rgbToHex(lighten(brandColors.ticketState.todo, 0.5)),
+        id: `First Commit to PR Time`,
+        color: rgbToHex(darken(brandColors.ticketState.todo, 0.2)),
         data: firstCommitToOpenTrendsData.map((point, index) => ({
           x: yAxisLabels[index],
           y: point.y || 0
@@ -111,7 +111,7 @@ export const useDoraMetricsGraph = () => {
       },
       firstResponseTimeTrends: {
         id: `First Response Time`,
-        color: rgbToHex(lighten(brandColors.pr.firstResponseTime, 0.5)),
+        color: rgbToHex(lighten(brandColors.pr.firstResponseTime, 0.1)),
         data: firstResponseTimeTrendsData.map((point, index) => ({
           x: yAxisLabels[index],
           y: point.y || 0


### PR DESCRIPTION
This pull request adds the `type="password"` attribute to the Github Personal Access Token input field in the ConfigureGithubModalBody component. This ensures that the entered token is masked and not visible to others.