### PR TITLE
Implement GitLab search API to get projects

### DIFF
--- a/web-server/pages/api/internal/[org_id]/git_provider_org.ts
+++ b/web-server/pages/api/internal/[org_id]/git_provider_org.ts
@@ -25,19 +25,21 @@ const endpoint = new Endpoint(pathSchema);
 endpoint.handle.GET(getSchema, async (req, res) => {
   const { org_id, search_text, providers } = req.payload;
 
+  const providerMap = fetchMap.filter((item) =>
+    providers.includes(item.provider)
+  );
+
   const tokens = await Promise.all(
-    fetchMap
-      .filter((item) => providers.includes(item.provider))
-      .map((item) => item.getToken(org_id))
+    providerMap.map((item) => item.getToken(org_id))
   );
 
   const repos = await Promise.all(
-    fetchMap
-      .filter((item) => providers.includes(item.provider))
-      .map((item) => item.search(tokens.shift(), search_text))
+    providerMap.map((item) => item.search(tokens.shift(), search_text))
   );
 
-  return res.status(200).send(repos.flat());
+  const sortedRepos = repos.flat().sort((a, b) => a.name.localeCompare(b.name));
+
+  return res.status(200).send(sortedRepos);
 });
 
 export default endpoint.serve();

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -200,15 +200,3 @@ export const searchGitlabRepos = async (
       }) as BaseRepo
   );
 };
-
-// Usage example
-const accessToken = '<your_access_token>';
-const searchQuery = 'example';
-
-searchGitlabRepos(accessToken, searchQuery)
-  .then((data) => {
-    console.log('GitLab Repositories:', data);
-  })
-  .catch((error) => {
-    console.error('Error:', error);
-  });

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -34,6 +34,20 @@ type RepoReponse = {
 
 export const searchGithubRepos = async (
   pat: string,
+  searchQuery: string
+): Promise<BaseRepo[]> => {
+  let urlString = searchQuery;
+  urlString = urlString.replace('https://', '');
+  urlString = urlString.replace('http://', '');
+  urlString = urlString.replace('www.', '');
+  urlString = urlString.replace('github.com/', '');
+  urlString = urlString.endsWith('/') ? urlString.slice(0, -1) : urlString;
+
+  return searchGithubReposWithNames(pat, urlString);
+};
+
+export const searchGithubReposWithNames = async (
+  pat: string,
   searchString: string
 ): Promise<BaseRepo[]> => {
   const query = `

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -20,7 +20,8 @@ type GithubRepo = {
   owner: {
     login: string;
   };
-  html_url: string;
+  html_url?: string;
+  id?: number;
 };
 
 type RepoReponse = {
@@ -55,7 +56,7 @@ const searchRepoWithURL = async (searchString: string) => {
   const repo = response.data;
   return [
     {
-      id: repo.databaseId,
+      id: repo.id,
       name: repo.name,
       desc: repo.description,
       slug: repo.name,

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -106,12 +106,7 @@ interface RepoNode {
   webUrl: string;
   description: string | null;
   path: string;
-  group: {
-    fullName: string;
-  };
-  namespace: {
-    fullName: string;
-  };
+  fullPath: string;
   nameWithNamespace: string;
   languages: {
     nodes: {
@@ -143,14 +138,8 @@ export const searchGitlabRepos = async (
       projects(search: $searchString, first: 50) {
           nodes {
               id
-              group {
-                  fullName
-              }
-              namespace {
-                  fullName
-              }
+              fullPath
               name
-              nameWithNamespace
               webUrl
               description
               path
@@ -189,14 +178,13 @@ export const searchGitlabRepos = async (
   return repositories.map(
     (repo) =>
       ({
-        id: repo.id,
+        id: Number(repo.id.replace('gid://gitlab/Project/', '')),
         name: repo.name,
         desc: repo.description,
         slug: repo.path,
         web_url: repo.webUrl,
         branch: repo.repository?.rootRef || null,
-        // TODO: fix this
-        parent: repo.nameWithNamespace.split(' / ')[0]
+        parent: repo.fullPath.replace('https://gitlab.com/', '').split('/')[0]
       }) as BaseRepo
   );
 };

--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -249,5 +249,5 @@ export const gitlabSearch = async (pat: string, searchString: string) => {
     results = await searchProjects(groupName, projectQuery, pat);
   }
   if (results?.length) return results;
-  else return searchGitlabRepos(pat, searchString);
+  else return searchGitlabRepos(pat, projectQuery || searchString);
 };

--- a/web-server/pages/integrations.tsx
+++ b/web-server/pages/integrations.tsx
@@ -71,8 +71,8 @@ const Content = () => {
   const lastSyncMap = useMemo(() => {
     return integrationList
       .map((item) => {
-        // @ts-ignore
-        const linkedAt = integrations[item].linked_at;
+        const linkedAt =
+          integrations[item as 'github' | 'gitlab' | 'bitbucket'].linked_at;
         if (!linkedAt) return null;
         const codeProviderLinkedAt = new Date(linkedAt);
         const currentDate = new Date();

--- a/web-server/pages/integrations.tsx
+++ b/web-server/pages/integrations.tsx
@@ -1,13 +1,14 @@
 import { Add } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
 import { Button, Divider, Card } from '@mui/material';
+import { differenceInMilliseconds } from 'date-fns';
+import { millisecondsInMinute } from 'date-fns/constants';
 import { useEffect, useMemo } from 'react';
 import { Authenticated } from 'src/components/Authenticated';
 
 import { handleApi } from '@/api-helpers/axios-api-instance';
 import { FlexBox } from '@/components/FlexBox';
 import { Line } from '@/components/Text';
-import { Integration } from '@/constants/integrations';
 import { ROUTES } from '@/constants/routes';
 import { FetchState } from '@/constants/ui-states';
 import { GithubIntegrationCard } from '@/content/Dashboards/GithubIntegrationCard';
@@ -19,10 +20,10 @@ import ExtendedSidebarLayout from '@/layouts/ExtendedSidebarLayout';
 import { appSlice } from '@/slices/app';
 import { fetchTeams } from '@/slices/team';
 import { useDispatch, useSelector } from '@/store';
-import { PageLayout, IntegrationGroup } from '@/types/resources';
+import { PageLayout } from '@/types/resources';
 import { depFn } from '@/utils/fn';
 
-const TIME_LIMIT_FOR_FORCE_SYNC = 600000;
+const TIME_LIMIT_FOR_FORCE_SYNC = 10 * millisecondsInMinute;
 
 function Integrations() {
   const isLoading = useSelector(
@@ -57,14 +58,8 @@ Integrations.getLayout = (page: PageLayout) => (
 export default Integrations;
 
 const Content = () => {
-  const {
-    orgId,
-    integrations,
-    integrationSet,
-    activeCodeProvider,
-    integrationList
-  } = useAuth();
-  const hasCodeProviderLinked = integrationSet.has(IntegrationGroup.CODE);
+  const { orgId, integrations, integrationList } = useAuth();
+  const hasCodeProviderLinked = integrationList.length > 0;
   const teamCount = useSelector((s) => s.team.teams?.length);
   const dispatch = useDispatch();
   const loadedTeams = useBoolState(false);
@@ -72,29 +67,42 @@ const Content = () => {
   const localLastForceSyncedAt = useEasyState<Date | null>(null);
   const showCreationCTA =
     hasCodeProviderLinked && !teamCount && loadedTeams.value;
+
+  const lastSyncMap = useMemo(() => {
+    return integrationList
+      .map((item) => {
+        // @ts-ignore
+        const linkedAt = integrations[item].linked_at;
+        if (!linkedAt) return null;
+        const codeProviderLinkedAt = new Date(linkedAt);
+        const currentDate = new Date();
+        const diff = differenceInMilliseconds(
+          currentDate,
+          codeProviderLinkedAt
+        );
+        return diff;
+      })
+      .filter(Boolean);
+  }, [integrationList, integrations]);
+
   const showForceSyncBtn = useMemo(() => {
     if (!hasCodeProviderLinked) return false;
-    const githubLinkedAt = new Date(integrations[Integration.GITHUB].linked_at);
-    const currentDate = new Date();
-    if (githubLinkedAt) {
-      const diffMilliseconds = currentDate.getTime() - githubLinkedAt.getTime();
-      return diffMilliseconds >= TIME_LIMIT_FOR_FORCE_SYNC;
-    }
-  }, [hasCodeProviderLinked, integrations]);
+    if (!lastSyncMap.length) return true;
+    return lastSyncMap.every((diff) => diff >= TIME_LIMIT_FOR_FORCE_SYNC);
+  }, [hasCodeProviderLinked, lastSyncMap]);
 
   const enableForceSyncBtn = useMemo(() => {
-    if (!integrations[activeCodeProvider]?.last_synced_at) return true;
-    const lastForceSyncedAt = Math.max(
-      new Date(integrations[activeCodeProvider]?.last_synced_at).getTime(),
-      localLastForceSyncedAt.value?.getTime()
+    const diff = differenceInMilliseconds(
+      new Date(),
+      localLastForceSyncedAt.value
     );
-    const currentDate = new Date();
-    const diffMilliseconds = currentDate.getTime() - lastForceSyncedAt;
-    return diffMilliseconds >= TIME_LIMIT_FOR_FORCE_SYNC;
-  }, [activeCodeProvider, integrations, localLastForceSyncedAt.value]);
+    if (diff >= TIME_LIMIT_FOR_FORCE_SYNC) return true;
+    if (!lastSyncMap.length) return true;
+    return lastSyncMap.some((diff) => diff >= TIME_LIMIT_FOR_FORCE_SYNC);
+  }, [lastSyncMap, localLastForceSyncedAt.value]);
 
   useEffect(() => {
-    if (!orgId || !activeCodeProvider) return;
+    if (!orgId || !integrationList.length) return;
     if (!hasCodeProviderLinked) {
       dispatch(appSlice.actions.setSingleTeam([]));
       return;
@@ -108,7 +116,6 @@ const Content = () => {
       ).finally(loadedTeams.true);
     }
   }, [
-    activeCodeProvider,
     dispatch,
     hasCodeProviderLinked,
     integrationList,
@@ -142,7 +149,7 @@ const Content = () => {
             transition: 'all 0.2s ease'
           }}
         >
-          Integrate your Github to fetch DORA for your team
+          Integrate your Code Providers to fetch DORA for your team
         </Line>
         {showDoraCTA && (
           <Button href={ROUTES.DORA_METRICS.PATH} variant="contained">

--- a/web-server/pages/integrations.tsx
+++ b/web-server/pages/integrations.tsx
@@ -57,7 +57,13 @@ Integrations.getLayout = (page: PageLayout) => (
 export default Integrations;
 
 const Content = () => {
-  const { orgId, integrations, integrationSet, activeCodeProvider } = useAuth();
+  const {
+    orgId,
+    integrations,
+    integrationSet,
+    activeCodeProvider,
+    integrationList
+  } = useAuth();
   const hasCodeProviderLinked = integrationSet.has(IntegrationGroup.CODE);
   const teamCount = useSelector((s) => s.team.teams?.length);
   const dispatch = useDispatch();
@@ -97,7 +103,7 @@ const Content = () => {
       dispatch(
         fetchTeams({
           org_id: orgId,
-          provider: activeCodeProvider
+          providers: integrationList
         })
       ).finally(loadedTeams.true);
     }
@@ -105,6 +111,7 @@ const Content = () => {
     activeCodeProvider,
     dispatch,
     hasCodeProviderLinked,
+    integrationList,
     loadedTeams.true,
     orgId,
     teamCount

--- a/web-server/pages/teams/index.tsx
+++ b/web-server/pages/teams/index.tsx
@@ -4,7 +4,6 @@ import ExtendedSidebarLayout from 'src/layouts/ExtendedSidebarLayout';
 import { FlexBox } from '@/components/FlexBox';
 import { CreateEditTeams, Loader } from '@/components/Teams/CreateTeams';
 import { TeamsList } from '@/components/TeamsList';
-import { Integration } from '@/constants/integrations';
 import { useRedirectWithSession } from '@/constants/useRoute';
 import { PageWrapper } from '@/content/PullRequests/PageWrapper';
 import { useAuth } from '@/hooks/useAuth';
@@ -17,10 +16,7 @@ import { depFn } from '@/utils/fn';
 function Page() {
   useRedirectWithSession();
   const dispatch = useDispatch();
-  const {
-    orgId,
-    integrations: { github: isGithubIntegrated }
-  } = useAuth();
+  const { orgId, integrationList } = useAuth();
   const teamsList = useSelector((state) => state.team.teams);
   const loading = useBoolState(!Boolean(teamsList.length));
 
@@ -29,11 +25,11 @@ function Page() {
     await dispatch(
       fetchTeams({
         org_id: orgId,
-        provider: Integration.GITHUB
+        providers: integrationList
       })
     );
     depFn(loading.false);
-  }, [dispatch, loading.false, loading.true, orgId]);
+  }, [dispatch, integrationList, loading.false, loading.true, orgId]);
 
   useEffect(() => {
     if (!orgId) return;
@@ -51,7 +47,7 @@ function Page() {
       showEvenIfNoTeamSelected
       hideAllSelectors
     >
-      {isGithubIntegrated && !loading.value ? (
+      {integrationList.length && !loading.value ? (
         <FlexBox col gap={4}>
           {teamsList.length ? <TeamsList /> : <CreateEditTeams />}
         </FlexBox>

--- a/web-server/src/components/AnimatedInputWrapper/AnimatedInputWrapper.tsx
+++ b/web-server/src/components/AnimatedInputWrapper/AnimatedInputWrapper.tsx
@@ -4,17 +4,26 @@ import styles from './slider.module.css';
 
 const AnimatedInputWrapper = () => {
   return (
-    <div className={styles.placeholder}>
+    <div
+      className={styles.placeholder}
+      style={{ minWidth: '200px', zIndex: 2 }}
+    >
       <AnimatedPlaceHolderWrapper />
     </div>
   );
 };
 
-const popRepos = ['golang/go', 'mozilla/rust', 'apple/swift', 'oven-sh/bun'];
+const popRepos = [
+  'Search for golang/go',
+  'https://gitlab.com/ase/ase',
+  '...or mozilla/rust',
+  'github.com/oven-sh/bun',
+  '...even apple/swift'
+];
+
 const AnimatedPlaceHolderWrapper = () => {
   return (
     <div className={styles.animationWrapper}>
-      <span>Search for</span>
       <AnimatedRepos />
     </div>
   );
@@ -33,7 +42,7 @@ const AnimatedRepos = () => {
     return () => clearInterval(interval);
   });
   return (
-    <div className={styles.textslide}>
+    <div className={styles.textslide} style={{ zIndex: 2, minWidth: '300px' }}>
       <div
         className={styles.text}
         style={{ bottom: animationIndex * 1.4 + 'em' }}

--- a/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
+++ b/web-server/src/components/TeamSelector/useTeamSelectorSetup.tsx
@@ -3,7 +3,6 @@ import pluralize, { plural } from 'pluralize';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Integration } from '@/constants/integrations';
 import { FetchState } from '@/constants/ui-states';
 import { useAuth } from '@/hooks/useAuth';
 import { useStateTeamConfig } from '@/hooks/useStateTeamConfig';
@@ -22,10 +21,7 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
   const dispatch = useDispatch();
   const { dateRange, singleTeam, setRange, partiallyUnselected } =
     useStateTeamConfig();
-  const {
-    orgId,
-    integrations: { github: isGithubIntegrations }
-  } = useAuth();
+  const { orgId, integrationList } = useAuth();
   const [showAllTeams, setShowAllTeams] = useState(true);
   const activeBranchMode = useSelector((state) => state.app.branchMode);
   const isAllBranchMode = activeBranchMode === ActiveBranchMode.ALL;
@@ -56,10 +52,10 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
 
   const fetchAllTeams = useCallback(async () => {
     await Promise.all([
-      dispatch(fetchTeams({ org_id: orgId, provider: Integration.GITHUB })),
+      dispatch(fetchTeams({ org_id: orgId, providers: integrationList })),
       dispatch(updateTeamBranchesMap({ orgId }))
     ]);
-  }, [dispatch, orgId]);
+  }, [dispatch, integrationList, orgId]);
 
   const apiTeams = useSelector((state) => state.team.teams);
   const loadingTeams = useSelector(
@@ -69,8 +65,8 @@ export const useTeamSelectorSetup = ({ mode }: UseTeamSelectorSetupArgs) => {
   useEffect(() => {
     if (!orgId) return;
 
-    if (isGithubIntegrations) fetchAllTeams();
-  }, [fetchAllTeams, isGithubIntegrations, orgId]);
+    if (integrationList.length) fetchAllTeams();
+  }, [fetchAllTeams, integrationList.length, orgId]);
 
   const dateRangeLabel = !partiallyUnselected
     ? `${format(dateRange[0], 'do MMM')} to ${format(dateRange[1], 'do MMM')}`

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -217,7 +217,7 @@ const TeamRepos: FC = () => {
           options={repoOptions}
           value={selectedRepos}
           onChange={handleRepoSelectionChange}
-          getOptionLabel={(option) => `${option.parent}/${option.name}`}
+          getOptionLabel={(option) => option.web_url}
           renderInput={(params) => (
             <TextField
               onKeyDown={(event) => {

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -382,9 +382,7 @@ const DisplayRepos: FC = () => {
           <TableRow>
             <TableCell sx={{ px: 2, minWidth: 200 }}>Repo</TableCell>
             <TableCell sx={{ p: 1 }}>Deployed Via</TableCell>
-            <TableCell align="center" sx={{ p: 1 }}>
-              Action
-            </TableCell>
+            <TableCell align="right">Action</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -416,16 +414,17 @@ const DisplayRepos: FC = () => {
                 </TableCell>
                 <TableCell>
                   <FlexBox
+                    fit
+                    ml={'auto'}
                     title="Delete repo"
                     pointer
-                    sx={{ px: 1 }}
-                    justifyCenter
+                    justifyEnd
                     alignCenter
                     onClick={() => {
                       unselectRepo(repo.id);
                     }}
                   >
-                    <DeleteIcon fontSize="small" color="error" />
+                    <DeleteIcon fontSize="small" color="warning" />
                   </FlexBox>
                 </TableCell>
               </TableRow>
@@ -473,7 +472,7 @@ const DeploymentSourceSelector: FC<{ repo: BaseRepo }> = ({ repo }) => {
         col
         title={
           repo.provider === Integration.GITLAB ? (
-            <Line>Gitlab repos only support PR merge deployments</Line>
+            <Line>Gitlab repos only support PR merge deployments for now</Line>
           ) : (
             ''
           )

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -32,6 +32,7 @@ import { Integration } from '@/constants/integrations';
 import { useBoolState, useEasyState } from '@/hooks/useEasyState';
 import GitlabIcon from '@/mocks/icons/gitlab.svg';
 import { BaseRepo, DeploymentSources } from '@/types/resources';
+import { trimWithEllipsis } from '@/utils/stringFormatting';
 
 import AnimatedInputWrapper from '../AnimatedInputWrapper/AnimatedInputWrapper';
 import { FlexBox } from '../FlexBox';
@@ -387,42 +388,49 @@ const DisplayRepos: FC = () => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {selectedRepos.map((repo) => (
-            <TableRow key={repo.id}>
-              <TableCell sx={{ px: 2 }}>
-                <FlexBox gap1 alignCenter>
-                  {repo.provider === Integration.GITHUB ? (
-                    <GitHub sx={{ fontSize: '16px' }} />
-                  ) : (
-                    <GitlabIcon height={14} width={14} />
-                  )}
-                  {repo.name}
-                </FlexBox>
-              </TableCell>
-              <TableCell sx={{ px: 1, minWidth: 200 }}>
-                <FlexBox gap2 alignCenter>
-                  <DeploymentSourceSelector repo={repo} />{' '}
-                  {repo.deployment_type === DeploymentSources.WORKFLOW && (
-                    <DeploymentWorkflowSelector repo={repo} />
-                  )}
-                </FlexBox>
-              </TableCell>
-              <TableCell>
-                <FlexBox
-                  title="Delete repo"
-                  pointer
-                  sx={{ px: 1 }}
-                  justifyCenter
-                  alignCenter
-                  onClick={() => {
-                    unselectRepo(repo.id);
-                  }}
-                >
-                  <DeleteIcon fontSize="small" color="error" />
-                </FlexBox>
-              </TableCell>
-            </TableRow>
-          ))}
+          {selectedRepos.map((repo) => {
+            const shortenedName = trimWithEllipsis(repo.name, 40);
+            return (
+              <TableRow key={repo.id}>
+                <TableCell sx={{ px: 2 }}>
+                  <FlexBox
+                    title={shortenedName === repo.name ? null : repo.name}
+                    gap1
+                    alignCenter
+                  >
+                    {repo.provider === Integration.GITHUB ? (
+                      <GitHub sx={{ fontSize: '16px' }} />
+                    ) : (
+                      <GitlabIcon height={14} width={14} />
+                    )}
+                    {shortenedName}
+                  </FlexBox>
+                </TableCell>
+                <TableCell sx={{ px: 1, minWidth: 200 }}>
+                  <FlexBox gap2 alignCenter>
+                    <DeploymentSourceSelector repo={repo} />{' '}
+                    {repo.deployment_type === DeploymentSources.WORKFLOW && (
+                      <DeploymentWorkflowSelector repo={repo} />
+                    )}
+                  </FlexBox>
+                </TableCell>
+                <TableCell>
+                  <FlexBox
+                    title="Delete repo"
+                    pointer
+                    sx={{ px: 1 }}
+                    justifyCenter
+                    alignCenter
+                    onClick={() => {
+                      unselectRepo(repo.id);
+                    }}
+                  >
+                    <DeleteIcon fontSize="small" color="error" />
+                  </FlexBox>
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
         {showWorkflowChangeWarning && (
           <TableRow>

--- a/web-server/src/components/Teams/CreateTeams.tsx
+++ b/web-server/src/components/Teams/CreateTeams.tsx
@@ -198,7 +198,7 @@ const TeamRepos: FC = () => {
         <Line big semibold>
           Add Repositories
         </Line>
-        <Line>Select repositories for this team</Line>
+        <Line>Select repositories for this team using name or link</Line>
       </FlexBox>
       <FlexBox>
         <Autocomplete

--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -87,7 +87,8 @@ export const TeamsCRUDProvider: React.FC<{
   const dispatch = useDispatch();
   const teamReposMaps = useSelector((s) => s.team.teamReposMaps);
   const teams = useSelector((s) => s.team.teams);
-  const { orgId } = useAuth();
+  const { orgId, integrationList } = useAuth();
+
   const isPageLoading = useSelector(
     (s) => s.team.requests?.teams === FetchState.REQUEST
   );
@@ -98,10 +99,10 @@ export const TeamsCRUDProvider: React.FC<{
     dispatch(
       fetchTeams({
         org_id: orgId,
-        provider: Integration.GITHUB
+        providers: integrationList
       })
     );
-  }, [dispatch, orgId]);
+  }, [dispatch, integrationList, orgId]);
 
   // team name logic
   const teamName = useEasyState('');
@@ -446,7 +447,8 @@ const repoToPayload = (repos: BaseRepo[]) => {
       slug: repo.slug,
       default_branch: repo.branch,
       deployment_type: repo.deployment_type,
-      repo_workflows: repo.repo_workflows
+      repo_workflows: repo.repo_workflows,
+      provider: repo.provider
     };
     const orgName = repo.parent;
 
@@ -465,6 +467,8 @@ const DEBOUNCE_TIME = 500;
 const useReposSearch = () => {
   const { orgId } = useAuth();
   const searchResults = useEasyState<BaseRepo[]>([]);
+  const { integrationList } = useAuth();
+
   const isLoading = useBoolState(false);
 
   let cancelTokenSource = axios.CancelToken.source();
@@ -496,7 +500,7 @@ const useReposSearch = () => {
         const response = await axios(
           `/api/internal/${orgId}/git_provider_org`,
           {
-            params: { provider: Integration.GITHUB, search_text: query },
+            params: { providers: integrationList, search_text: query },
             cancelToken: cancelTokenSource.token
           }
         );

--- a/web-server/src/components/Teams/useTeamsConfig.tsx
+++ b/web-server/src/components/Teams/useTeamsConfig.tsx
@@ -532,5 +532,6 @@ const adaptBaseRepo = (repo: DB_OrgRepo): BaseRepo =>
     branch: repo.default_branch,
     parent: repo.org_name,
     deployment_type: repo.deployment_type,
-    repo_workflows: repo.repo_workflows
+    repo_workflows: repo.repo_workflows,
+    provider: repo.provider
   }) as unknown as BaseRepo;

--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -13,7 +13,6 @@ import { ascend } from 'ramda';
 import { FC, MouseEventHandler, useCallback, useMemo } from 'react';
 import { truncate } from 'voca';
 
-import { Integration } from '@/constants/integrations';
 import { ROUTES } from '@/constants/routes';
 import { FetchState } from '@/constants/ui-states';
 import { useAuth } from '@/hooks/useAuth';
@@ -258,7 +257,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit }) => {
 const MoreOptions = ({ teamId }: { teamId: ID }) => {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
-  const { orgId } = useAuth();
+  const { orgId, integrationList } = useAuth();
   const anchorEl = useEasyState();
   const loading = useBoolState(false);
   const cancelMenu = useBoolState(false);
@@ -286,9 +285,7 @@ const MoreOptions = ({ teamId }: { teamId: ID }) => {
               variant: 'success',
               autoHideDuration: 2000
             });
-            dispatch(
-              fetchTeams({ org_id: orgId, provider: Integration.GITHUB })
-            );
+            dispatch(fetchTeams({ org_id: orgId, providers: integrationList }));
             handleCloseMenu();
           } else {
             enqueueSnackbar('Failed to delete team', {
@@ -304,6 +301,7 @@ const MoreOptions = ({ teamId }: { teamId: ID }) => {
       dispatch,
       enqueueSnackbar,
       handleCloseMenu,
+      integrationList,
       loading.false,
       loading.true,
       orgId

--- a/web-server/src/content/Dashboards/ConfigureGithubModalBody.tsx
+++ b/web-server/src/content/Dashboards/ConfigureGithubModalBody.tsx
@@ -23,7 +23,7 @@ export const ConfigureGithubModalBody: FC<{
   onClose: () => void;
 }> = ({ onClose }) => {
   const token = useEasyState('');
-  const { orgId } = useAuth();
+  const { orgId, integrationList } = useAuth();
   const { enqueueSnackbar } = useSnackbar();
   const dispatch = useDispatch();
   const isLoading = useBoolState();
@@ -79,7 +79,7 @@ export const ConfigureGithubModalBody: FC<{
         dispatch(
           fetchTeams({
             org_id: orgId,
-            provider: Integration.GITHUB
+            providers: integrationList
           })
         );
         enqueueSnackbar('Github linked successfully', {
@@ -96,6 +96,7 @@ export const ConfigureGithubModalBody: FC<{
   }, [
     dispatch,
     enqueueSnackbar,
+    integrationList,
     isLoading.false,
     isLoading.true,
     onClose,

--- a/web-server/src/content/Dashboards/ConfigureGitlabModalBody.tsx
+++ b/web-server/src/content/Dashboards/ConfigureGitlabModalBody.tsx
@@ -24,7 +24,7 @@ export const ConfigureGitlabModalBody: FC<{
 }> = ({ onClose }) => {
   const token = useEasyState('');
   const customDomain = useEasyState('');
-  const { orgId } = useAuth();
+  const { orgId, integrationList } = useAuth();
   const { enqueueSnackbar } = useSnackbar();
   const dispatch = useDispatch();
   const isLoading = useBoolState();
@@ -106,7 +106,7 @@ export const ConfigureGitlabModalBody: FC<{
         dispatch(
           fetchTeams({
             org_id: orgId,
-            provider: Integration.GITLAB
+            providers: integrationList
           })
         );
         enqueueSnackbar('Gitlab linked successfully', {
@@ -124,6 +124,7 @@ export const ConfigureGitlabModalBody: FC<{
     customDomain.value,
     dispatch,
     enqueueSnackbar,
+    integrationList,
     isLoading.false,
     isLoading.true,
     onClose,

--- a/web-server/src/contexts/ThirdPartyAuthContext.tsx
+++ b/web-server/src/contexts/ThirdPartyAuthContext.tsx
@@ -25,6 +25,7 @@ export interface AuthContextValue extends AuthState {
   role: UserRole;
   integrations: Org['integrations'];
   onboardingState: OnboardingStep[];
+  integrationList: Integration[];
   integrationSet: Set<IntegrationGroup>;
   activeCodeProvider: CodeProviderIntegrations | null;
 }
@@ -35,6 +36,7 @@ export const AuthContext = createContext<AuthContextValue>({
   role: UserRole.MOM,
   integrations: {},
   onboardingState: [],
+  integrationList: [],
   integrationSet: new Set(),
   activeCodeProvider: null
 });
@@ -113,6 +115,14 @@ export const AuthProvider: FC = (props) => {
     [integrations.github]
   );
 
+  const integrationList = useMemo(
+    () =>
+      Object.entries(integrations)
+        .filter(([_, value]) => value.integrated)
+        .map(([key, _]) => key) as Integration[],
+    [integrations]
+  );
+
   const activeCodeProvider = useMemo(
     () =>
       Object.keys(state?.org?.integrations || {}).find(
@@ -131,6 +141,7 @@ export const AuthProvider: FC = (props) => {
         role,
         integrations,
         integrationSet,
+        integrationList,
         activeCodeProvider,
         onboardingState: (state.org?.onboarding_state as OnboardingStep[]) || []
       }}

--- a/web-server/src/slices/repos.ts
+++ b/web-server/src/slices/repos.ts
@@ -203,10 +203,10 @@ export const fetchUnassignedRepos = createAsyncThunk(
 
 export const fetchProviderOrgs = createAsyncThunk(
   'repos/fetchProviderOrgs',
-  async (params: { orgId: ID; provider: Integration }) => {
+  async (params: { orgId: ID; providers: Integration[] }) => {
     return await handleApi<LoadedOrg[]>(
       `/internal/${params.orgId}/git_provider_org`,
-      { params: { provider: params.provider } }
+      { params: { providers: params.providers } }
     );
   }
 );
@@ -214,7 +214,7 @@ export const fetchProviderOrgs = createAsyncThunk(
 export const fetchReposForOrgFromProvider = createAsyncThunk(
   'repos/fetchReposForOrgFromProvider',
   async (
-    params: { orgId: ID; provider: Integration; orgName: string },
+    params: { orgId: ID; providers: Integration[]; orgName: string },
     { getState }
   ) => {
     const {
@@ -225,7 +225,7 @@ export const fetchReposForOrgFromProvider = createAsyncThunk(
       `/internal/${params.orgId}/git_provider_org`,
       {
         params: {
-          provider: params.provider,
+          providers: params.providers,
           org_name: params.orgName,
           team_id: selectedTeam?.value
         }

--- a/web-server/src/slices/team.ts
+++ b/web-server/src/slices/team.ts
@@ -135,7 +135,7 @@ export const teamSlice = createSlice({
 
 export const fetchTeams = createAsyncThunk(
   'teams/fetchTeams',
-  async (params: { org_id: ID; provider: Integration }) => {
+  async (params: { org_id: ID; providers: Integration[] }) => {
     return await handleApi<{
       teams: Team[];
       teamReposMap: Record<ID, DB_OrgRepo[]>;

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -462,7 +462,12 @@ export type RepoWithMultipleWorkflows = Omit<
 
 export type RepoUniqueDetails = Pick<
   RepoWithMultipleWorkflows,
-  'name' | 'slug' | 'default_branch' | 'idempotency_key' | 'deployment_type'
+  | 'name'
+  | 'slug'
+  | 'default_branch'
+  | 'idempotency_key'
+  | 'deployment_type'
+  | 'provider'
 > & { repo_workflows: AdaptedRepoWorkflow[] };
 
 export type RepoContributors = {

--- a/web-server/src/types/resources.ts
+++ b/web-server/src/types/resources.ts
@@ -250,6 +250,7 @@ export type BaseRepo = {
   branch: string;
   deployment_type: DeploymentSources;
   repo_workflows: AdaptedRepoWorkflow[];
+  provider?: Integration;
 };
 
 export enum NotificationType {


### PR DESCRIPTION
https://github.com/middlewarehq/middleware/issues/455

This pull request adds functionality to search for projects using GitLab's search API. 

- It includes the implementation of the `searchGitlabRepos` function, which allows searching for repositories on GitLab based on a search string. 

- The function makes use of the GitLab GraphQL API and returns a list of repositories that match the search query. 

- Retrieves repositories from both `GitHub` and `GitLab` when searching for repositories. 

This enhances the search functionality by including repositories from both platforms in the search results.

https://github.com/user-attachments/assets/f6b20101-cd66-42d5-ab9c-d5e3838c52ca