### PR TITLE
fix mtd bookmark pushback to take minimum value

### DIFF
--- a/backend/analytics_server/mhq/service/merge_to_deploy_broker/utils.py
+++ b/backend/analytics_server/mhq/service/merge_to_deploy_broker/utils.py
@@ -38,6 +38,11 @@ class MergeToDeployBrokerUtils:
                 repo_id=repo_id, bookmark=min_merged_time.isoformat()
             )
 
+        merge_to_deploy_broker_bookmark.bookmark = min(
+            datetime.fromisoformat(merge_to_deploy_broker_bookmark.bookmark),
+            min_merged_time,
+        )
+
         self.code_repo_service.update_merge_to_deploy_broker_bookmark(
             merge_to_deploy_broker_bookmark
         )

--- a/backend/analytics_server/mhq/service/merge_to_deploy_broker/utils.py
+++ b/backend/analytics_server/mhq/service/merge_to_deploy_broker/utils.py
@@ -41,7 +41,7 @@ class MergeToDeployBrokerUtils:
         merge_to_deploy_broker_bookmark.bookmark = min(
             datetime.fromisoformat(merge_to_deploy_broker_bookmark.bookmark),
             min_merged_time,
-        )
+        ).isoformat()
 
         self.code_repo_service.update_merge_to_deploy_broker_bookmark(
             merge_to_deploy_broker_bookmark


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [x] Fixes the bookmark logic

## Proposed changes (including videos or screenshots)

- The merge_to_deploy logic depends on the workflow as well as the PRs. For each workflow we calculate the MTD for previously merged PRs for null MTD values.
- Incase the PRs are merge later we push the MTD bookmark so that mtd values are fixed on the next sync. This would require us to take the min of the existing bookmark and the pr merge times.
- The current change enforces the above logic. The previous logic would not change the bookmark regardless of the PRs merge times.
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
