### PR TITLE
remove inspect image job from build workflow as it is useless right now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,9 +181,6 @@ jobs:
           docker buildx imagetools create ${{ env.DOCKER_TAG }} \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
-      - name: Inspect image
-        run: docker buildx imagetools inspect $(echo "${{ env.DOCKER_TAG }}" | sed 's/-t //g')
-
   stop-runner-arm:
     name: Stop self-hosted EC2 arm runner
     needs:


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [ ] Task 1
- [ ] Task 2
- [ ] Task 3

## Proposed changes (including videos or screenshots)
remove inspect image job from build workflow as it is useless right now
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
