### PR TITLE
Added methods for feature Prs_not_reviwed_Merged in PulllrequestAnalysis Service

### DIFF
--- a/backend/analytics_server/mhq/api/pull_requests.py
+++ b/backend/analytics_server/mhq/api/pull_requests.py
@@ -168,6 +168,7 @@ def get_team_lead_time_trends(
         for week, average_lead_time_metrics in weekly_lead_time_metrics_avg_map.items()
     }
 
+
 @app.route("/teams/<team_id>/prs/merged_without_review", methods={"GET"})
 @queryschema(
     Schema(
@@ -177,16 +178,11 @@ def get_team_lead_time_trends(
         }
     ),
 )
-def merged_without_review(
-    team_id : str,
-    from_time: datetime,
-    to_time: datetime
-):
+def merged_without_review(team_id: str, from_time: datetime, to_time: datetime):
     query_validator = get_query_validator()
     team: Team = query_validator.team_validator(team_id)
     interval: Interval = query_validator.interval_validator(from_time, to_time)
     pr_analytics = get_pr_analytics_service()
-    result = pr_analytics.get_prs_merged_without_review(team.id,interval)
+    result = pr_analytics.get_prs_merged_without_review(team.id, interval)
     prs_map = [pr.id for pr in result]
-    return {'PrsWithoutReviewMerged': prs_map}
-    
+    return {"PrsWithoutReviewMerged": prs_map}

--- a/backend/analytics_server/mhq/api/pull_requests.py
+++ b/backend/analytics_server/mhq/api/pull_requests.py
@@ -168,12 +168,25 @@ def get_team_lead_time_trends(
         for week, average_lead_time_metrics in weekly_lead_time_metrics_avg_map.items()
     }
 
-@app.route("/teams/<team_id>/prs/merged_not_reviwed", methods={"GET"})
-def merge_not_reviwed(team_id : str):
+@app.route("/teams/<team_id>/prs/merged_without_review", methods={"GET"})
+@queryschema(
+    Schema(
+        {
+            Required("from_time"): All(str, Coerce(datetime.fromisoformat)),
+            Required("to_time"): All(str, Coerce(datetime.fromisoformat)),
+        }
+    ),
+)
+def merged_without_review(
+    team_id : str,
+    from_time: datetime,
+    to_time: datetime
+):
     query_validator = get_query_validator()
     team: Team = query_validator.team_validator(team_id)
+    interval: Interval = query_validator.interval_validator(from_time, to_time)
     pr_analytics = get_pr_analytics_service()
-    result = pr_analytics.get_prs_not_reviewed_merged(team.id)
-    return result
-    # return {'message':'hellothere'}
+    result = pr_analytics.get_prs_merged_without_review(team.id,interval)
+    prs_map = [pr.id for pr in result]
+    return {'PrsWithoutReviewMerged': prs_map}
     

--- a/backend/analytics_server/mhq/api/pull_requests.py
+++ b/backend/analytics_server/mhq/api/pull_requests.py
@@ -167,3 +167,13 @@ def get_team_lead_time_trends(
         week.isoformat(): adapt_lead_time_metrics(average_lead_time_metrics)
         for week, average_lead_time_metrics in weekly_lead_time_metrics_avg_map.items()
     }
+
+@app.route("/teams/<team_id>/prs/merged_not_reviwed", methods={"GET"})
+def merge_not_reviwed(team_id : str):
+    query_validator = get_query_validator()
+    team: Team = query_validator.team_validator(team_id)
+    pr_analytics = get_pr_analytics_service()
+    result = pr_analytics.get_prs_not_reviewed_merged(team.id)
+    return result
+    # return {'message':'hellothere'}
+    

--- a/backend/analytics_server/mhq/api/resources/code_resouces.py
+++ b/backend/analytics_server/mhq/api/resources/code_resouces.py
@@ -172,3 +172,8 @@ def adapt_team_repos(team_repos: List[TeamRepos]) -> List[Dict[str, any]]:
         }
         for team_repo in team_repos
     ]
+
+def get_non_paginated_merged_without_review(prs: List[PullRequest]) -> List[Dict[str,any]]:
+    return {
+        "data": []
+    }

--- a/backend/analytics_server/mhq/api/resources/code_resouces.py
+++ b/backend/analytics_server/mhq/api/resources/code_resouces.py
@@ -172,8 +172,3 @@ def adapt_team_repos(team_repos: List[TeamRepos]) -> List[Dict[str, any]]:
         }
         for team_repo in team_repos
     ]
-
-def get_non_paginated_merged_without_review(prs: List[PullRequest]) -> List[Dict[str,any]]:
-    return {
-        "data": []
-    }

--- a/backend/analytics_server/mhq/service/code/pr_analytics.py
+++ b/backend/analytics_server/mhq/service/code/pr_analytics.py
@@ -16,8 +16,11 @@ class PullRequestAnalyticsService:
     def get_prs_merged_without_review(
         self, team_id: str, interval: Interval, pr_filter: dict
     ) -> List[PullRequest]:
+        team_repos = self.code_repo_service.get_team_repos(team_id)
+        repo_ids = [team_repo.id for team_repo in team_repos]
+
         return self.code_repo_service.get_prs_merged_without_review(
-            team_id, interval, pr_filter
+            repo_ids, interval, pr_filter
         )
 
     def get_team_repos(self, team_id: str) -> List[OrgRepo]:

--- a/backend/analytics_server/mhq/service/code/pr_analytics.py
+++ b/backend/analytics_server/mhq/service/code/pr_analytics.py
@@ -10,6 +10,9 @@ class PullRequestAnalyticsService:
 
     def get_prs_by_ids(self, pr_ids: List[str]) -> List[PullRequest]:
         return self.code_repo_service.get_prs_by_ids(pr_ids)
+    
+    def get_prs_not_reviewed_merged(self,team_id):
+        return self.code_repo_service.get_prs_not_reviewed_merged(team_id)
 
     def get_team_repos(self, team_id: str) -> List[OrgRepo]:
         return self.code_repo_service.get_team_repos(team_id)

--- a/backend/analytics_server/mhq/service/code/pr_analytics.py
+++ b/backend/analytics_server/mhq/service/code/pr_analytics.py
@@ -14,9 +14,11 @@ class PullRequestAnalyticsService:
         return self.code_repo_service.get_prs_by_ids(pr_ids)
 
     def get_prs_merged_without_review(
-        self, team_id: str, interval: Interval
+        self, team_id: str, interval: Interval, pr_filter: dict
     ) -> List[PullRequest]:
-        return self.code_repo_service.get_prs_merged_without_review(team_id, interval)
+        return self.code_repo_service.get_prs_merged_without_review(
+            team_id, interval, pr_filter
+        )
 
     def get_team_repos(self, team_id: str) -> List[OrgRepo]:
         return self.code_repo_service.get_team_repos(team_id)

--- a/backend/analytics_server/mhq/service/code/pr_analytics.py
+++ b/backend/analytics_server/mhq/service/code/pr_analytics.py
@@ -1,7 +1,9 @@
 from mhq.store.models.code import OrgRepo, PullRequest
 from mhq.store.repos.code import CodeRepoService
 
-from typing import List, Optional
+
+from typing import List,Optional
+from mhq.utils.time import Interval
 
 
 class PullRequestAnalyticsService:
@@ -11,8 +13,8 @@ class PullRequestAnalyticsService:
     def get_prs_by_ids(self, pr_ids: List[str]) -> List[PullRequest]:
         return self.code_repo_service.get_prs_by_ids(pr_ids)
     
-    def get_prs_not_reviewed_merged(self,team_id):
-        return self.code_repo_service.get_prs_not_reviewed_merged(team_id)
+    def get_prs_merged_without_review(self,team_id:str,interval:Interval) -> List[PullRequest]:
+        return self.code_repo_service.get_prs_merged_without_review(team_id,interval)
 
     def get_team_repos(self, team_id: str) -> List[OrgRepo]:
         return self.code_repo_service.get_team_repos(team_id)

--- a/backend/analytics_server/mhq/service/code/pr_analytics.py
+++ b/backend/analytics_server/mhq/service/code/pr_analytics.py
@@ -2,7 +2,7 @@ from mhq.store.models.code import OrgRepo, PullRequest
 from mhq.store.repos.code import CodeRepoService
 
 
-from typing import List,Optional
+from typing import List, Optional
 from mhq.utils.time import Interval
 
 
@@ -12,9 +12,11 @@ class PullRequestAnalyticsService:
 
     def get_prs_by_ids(self, pr_ids: List[str]) -> List[PullRequest]:
         return self.code_repo_service.get_prs_by_ids(pr_ids)
-    
-    def get_prs_merged_without_review(self,team_id:str,interval:Interval) -> List[PullRequest]:
-        return self.code_repo_service.get_prs_merged_without_review(team_id,interval)
+
+    def get_prs_merged_without_review(
+        self, team_id: str, interval: Interval
+    ) -> List[PullRequest]:
+        return self.code_repo_service.get_prs_merged_without_review(team_id, interval)
 
     def get_team_repos(self, team_id: str) -> List[OrgRepo]:
         return self.code_repo_service.get_team_repos(team_id)

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -368,23 +368,14 @@ class CodeRepoService:
         return self.get_repos_by_ids(team_repo_ids)
     
     @rollback_on_exc
-    def get_prs_not_reviewed_merged(self,team_id):
+    def get_prs_merged_without_review(self,team_id,interval) -> List[PullRequest]:
         AllOrg = self.get_team_repos(team_id)
         AllOrg_ids = [tr.id for tr in AllOrg]
-        print(AllOrg)
-        AllPullRequestEventReviweinOrgIds = (self._db.session.query(PullRequestEvent)
-                                  .filter(PullRequestEvent.org_repo_id.in_(AllOrg_ids))
-                                  .all()
-                                  )
-        ListofReviwedPrs = [ tr.pull_request_id for tr in AllPullRequestEventReviweinOrgIds]
-        AllPullRequestMergedNotReviwed = (self._db.session.query(PullRequest)
-                                          .filter(PullRequest.id.not_in(ListofReviwedPrs))
-                                          .filter(PullRequest.state == PullRequestState.MERGED)
+        return (self._db.session.query(PullRequest)
+                                          .filter(PullRequest.repo_id.in_(AllOrg_ids))
+                                          .filter(PullRequest.merge_time == None)
+                                          .filter(PullRequest.created_in_db_at.between(interval.from_time,interval.to_time))
                                           .all())
-        print(AllPullRequestMergedNotReviwed)
-        
-        return {"countofMergedReviewedPrs": len(AllPullRequestEventReviweinOrgIds),"countOfMergedNOtReviwedPrs":len(AllPullRequestMergedNotReviwed)}
-
 
     @rollback_on_exc
     def get_team_repos_by_team_id(self, team_id: str) -> List[TeamRepos]:

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -366,16 +366,22 @@ class CodeRepoService:
 
         team_repo_ids = [tr.org_repo_id for tr in team_repos]
         return self.get_repos_by_ids(team_repo_ids)
-    
+
     @rollback_on_exc
-    def get_prs_merged_without_review(self,team_id,interval) -> List[PullRequest]:
+    def get_prs_merged_without_review(self, team_id, interval) -> List[PullRequest]:
         AllOrg = self.get_team_repos(team_id)
         AllOrg_ids = [tr.id for tr in AllOrg]
-        return (self._db.session.query(PullRequest)
-                                          .filter(PullRequest.repo_id.in_(AllOrg_ids))
-                                          .filter(PullRequest.merge_time == None)
-                                          .filter(PullRequest.created_in_db_at.between(interval.from_time,interval.to_time))
-                                          .all())
+        return (
+            self._db.session.query(PullRequest)
+            .filter(PullRequest.repo_id.in_(AllOrg_ids))
+            .filter(PullRequest.merge_time == None)
+            .filter(
+                PullRequest.created_in_db_at.between(
+                    interval.from_time, interval.to_time
+                )
+            )
+            .all()
+        )
 
     @rollback_on_exc
     def get_team_repos_by_team_id(self, team_id: str) -> List[TeamRepos]:

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -368,20 +368,30 @@ class CodeRepoService:
         return self.get_repos_by_ids(team_repo_ids)
 
     @rollback_on_exc
-    def get_prs_merged_without_review(self, team_id, interval) -> List[PullRequest]:
+    def get_prs_merged_without_review(
+        self, team_id: str, interval: Interval, pr_filter: PRFilter = None
+    ) -> List[PullRequest]:
         AllOrg = self.get_team_repos(team_id)
         AllOrg_ids = [tr.id for tr in AllOrg]
-        return (
+        query = (
             self._db.session.query(PullRequest)
             .filter(PullRequest.repo_id.in_(AllOrg_ids))
+            .filter(PullRequest.state == PullRequestState.MERGED)
             .filter(PullRequest.merge_time == None)
             .filter(
-                PullRequest.created_in_db_at.between(
-                    interval.from_time, interval.to_time
+                or_(
+                    PullRequest.created_at.between(
+                        interval.from_time, interval.to_time
+                    ),
+                    PullRequest.updated_at.between(
+                        interval.from_time, interval.to_time
+                    ),
                 )
             )
-            .all()
         )
+        query = self._filter_prs(query, pr_filter)
+
+        return query.all()
 
     @rollback_on_exc
     def get_team_repos_by_team_id(self, team_id: str) -> List[TeamRepos]:

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -366,6 +366,25 @@ class CodeRepoService:
 
         team_repo_ids = [tr.org_repo_id for tr in team_repos]
         return self.get_repos_by_ids(team_repo_ids)
+    
+    @rollback_on_exc
+    def get_prs_not_reviewed_merged(self,team_id):
+        AllOrg = self.get_team_repos(team_id)
+        AllOrg_ids = [tr.id for tr in AllOrg]
+        print(AllOrg)
+        AllPullRequestEventReviweinOrgIds = (self._db.session.query(PullRequestEvent)
+                                  .filter(PullRequestEvent.org_repo_id.in_(AllOrg_ids))
+                                  .all()
+                                  )
+        ListofReviwedPrs = [ tr.pull_request_id for tr in AllPullRequestEventReviweinOrgIds]
+        AllPullRequestMergedNotReviwed = (self._db.session.query(PullRequest)
+                                          .filter(PullRequest.id.not_in(ListofReviwedPrs))
+                                          .filter(PullRequest.state == PullRequestState.MERGED)
+                                          .all())
+        print(AllPullRequestMergedNotReviwed)
+        
+        return {"countofMergedReviewedPrs": len(AllPullRequestEventReviweinOrgIds),"countOfMergedNOtReviwedPrs":len(AllPullRequestMergedNotReviwed)}
+
 
     @rollback_on_exc
     def get_team_repos_by_team_id(self, team_id: str) -> List[TeamRepos]:


### PR DESCRIPTION


## Linked Issue(s) 

#207 

## Acceptance Criteria fulfillment

- [x]  Add Python Backend API to fetch Teams PRs merged without review for a team.

## Proposed changes (including videos or screenshots)

### Added required method in PullrequestAnalysisService & route in the pull_request.py
- Added method which takes a team_id as the input , finds the list of org_repos from which we use to query the PullRequest realted tables
- Finds the Prs (ids of pull_requests ) which are reviewed ( from the PullRequestEvent ) and then filters the Prs which are not reviewed , and finally filters for the ones which are Merged and returns the count of Prs which are not Reviwed But Merged
