### PR TITLE
Update gh build workflow to add a new step for setting build date as env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,6 @@ jobs:
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
           echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_ENV
-          echo ${{ env.BUILD_DATE }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,10 @@ jobs:
       - name: Print build metadata
         run: echo "${{ toJson(steps.meta.outputs) }}"
 
+      - name: Set Build Date
+        id: set-build-date
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+
       - name: Build and push Docker image by digest
         id: build
         uses: docker/build-push-action@v5
@@ -110,7 +114,7 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           build-args: |
-            BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            BUILD_DATE=${{ env.BUILD_DATE }}
             MERGE_COMMIT_SHA=${{ github.sha }}
           tags: ${{ github.ref == 'refs/heads/main' && format('middlewareeng/middleware:latest') || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,10 @@ jobs:
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_ENV
+          echo ${{ env.BUILD_DATE }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,10 +104,6 @@ jobs:
 
       - name: Print build metadata
         run: echo "${{ toJson(steps.meta.outputs) }}"
-
-      - name: Set Build Date
-        id: set-build-date
-        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
       - name: Build and push Docker image by digest
         id: build


### PR DESCRIPTION

## Linked Issue(s) 

- PR #496 added a logic to store build date but the logic resulted in the build date being set a string instead of the date string 
![image](https://github.com/user-attachments/assets/693e0b40-7753-480a-a985-cd31c32c98fb)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [x] Add new step for build date and store it in env var

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
