### PR TITLE
industry dora scores enums

### DIFF
--- a/web-server/src/utils/dora.ts
+++ b/web-server/src/utils/dora.ts
@@ -6,6 +6,23 @@ import {
 } from 'date-fns/constants';
 import { isNil, mean, reject } from 'ramda';
 
+export enum IndustryStandardsDoraScores {
+  ALL_INDUSTRIES = 6.3,
+  EDUCATION = 6.5,
+  ENERGY = 6.1,
+  FINANCIAL_SERVICES = 6.5,
+  GOVERNMENT = 6.2,
+  HEALTHCARE_AND_PHARMACEUTICALS = 6.0,
+  INDUSTRIALS_AND_MANUFACTURING = 5.7,
+  INSURANCE = 6.2,
+  MEDIA_AND_ENTERTAINMENT = 7.2,
+  NON_PROFIT = 6.2,
+  RETAIL_CONSUMER_ECOMMERCE = 6.5,
+  TECHNOLOGY = 6.3,
+  TELECOMMUNICATIONS = 6.2,
+  OTHER = 6.7
+}
+
 export const getDoraScore = ({
   lt,
   df,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Added an enum for industry standard scores for `Dora Metrics`. We will later use this in the UI to display different standard scores based on the industry. 

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
