### PR TITLE
Update Incident Service ETL to use BookmarkService

### DIFF
--- a/backend/analytics_server/mhq/service/incidents/sync/etl_git_incidents_handler.py
+++ b/backend/analytics_server/mhq/service/incidents/sync/etl_git_incidents_handler.py
@@ -78,18 +78,18 @@ class GitIncidentsETLHandler(IncidentsProviderETLHandler):
     def process_service_incidents(
         self,
         incident_service: OrgIncidentService,
-        bookmark: IncidentsBookmark,
-    ) -> Tuple[List[Incident], List[IncidentOrgIncidentServiceMap], IncidentsBookmark]:
+        bookmark: datetime,
+    ) -> Tuple[List[Incident], List[IncidentOrgIncidentServiceMap], datetime]:
         """
         Sync incidents for the service
         :param incident_service: OrgIncidentService
-        :param bookmark: IncidentsBookmark
-        :return: List of Incidents, List of IncidentOrgIncidentServiceMap, IncidentsBookmark
+        :param bookmark: datetime
+        :return: List of Incidents, List of IncidentOrgIncidentServiceMap, datetime bookmark
         """
         if not incident_service or not isinstance(incident_service, OrgIncidentService):
             raise Exception(f"Service not found")
 
-        from_time: datetime = bookmark.bookmark
+        from_time: datetime = bookmark
         to_time: datetime = time_now()
 
         revert_pr_incidents: List[RevertPRMap] = (
@@ -108,7 +108,7 @@ class GitIncidentsETLHandler(IncidentsProviderETLHandler):
             key=lambda revert_pr_incident: revert_pr_incident.updated_at
         )
 
-        bookmark.bookmark = max(bookmark.bookmark, revert_pr_incidents[-1].updated_at)
+        bookmark = max(bookmark, revert_pr_incidents[-1].updated_at)
 
         incidents, incident_org_incident_service_map_models = self._process_incidents(
             incident_service, revert_pr_incidents

--- a/backend/analytics_server/mhq/service/incidents/sync/etl_provider_handler.py
+++ b/backend/analytics_server/mhq/service/incidents/sync/etl_provider_handler.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import List, Tuple
 
 from mhq.store.models.incidents import (
@@ -32,12 +33,12 @@ class IncidentsProviderETLHandler(ABC):
 
     @abstractmethod
     def process_service_incidents(
-        self, incident_service: OrgIncidentService, bookmark: IncidentsBookmark
-    ) -> Tuple[List[Incident], List[IncidentOrgIncidentServiceMap], IncidentsBookmark]:
+        self, incident_service: OrgIncidentService, bookmark: datetime
+    ) -> Tuple[List[Incident], List[IncidentOrgIncidentServiceMap], datetime]:
         """
         This method processes the incidents for the incident services.
         :param incident_service: Incident service object
-        :param bookmark: IncidentsBookmark object
+        :param bookmark: datetime object
         :return: Tuple of incidents, incident service map and incidents bookmark
         """
         pass


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
#500 
## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [ ] Update usage of BookmarkService throughout the codebase
    - [x] Update Incident ETL to use bookmark service

## Proposed changes (including videos or screenshots)

- update IncidentsProviderETLHandler.process_service_incidents to use datetime object as timestamp.
- update IncidentsETLHandler to use bookmark service.
- Use datetime object as bookmark for incident syncs

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
