### PR TITLE
Bookmark reset api

### DIFF
--- a/backend/analytics_server/app.py
+++ b/backend/analytics_server/app.py
@@ -14,6 +14,7 @@ from mhq.api.incidents import app as incidents_api
 from mhq.api.integrations import app as integrations_api
 from mhq.api.deployment_analytics import app as deployment_analytics_api
 from mhq.api.teams import app as teams_api
+from mhq.api.bookmark import app as bookmark_api
 
 from mhq.store.initialise_db import initialize_database
 
@@ -28,6 +29,7 @@ app.register_blueprint(incidents_api)
 app.register_blueprint(deployment_analytics_api)
 app.register_blueprint(integrations_api)
 app.register_blueprint(teams_api)
+app.register_blueprint(bookmark_api)
 
 configure_db_with_app(app)
 initialize_database(app)

--- a/backend/analytics_server/mhq/api/bookmark.py
+++ b/backend/analytics_server/mhq/api/bookmark.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta
+from flask import Blueprint
+from voluptuous import Schema, Coerce, All, Optional
+from mhq.api.request_utils import queryschema
+
+from mhq.store.models.settings import SettingType, EntityType
+from mhq.service.query_validator import get_query_validator
+from mhq.service.settings.configuration_settings import get_settings_service
+from mhq.service.settings.models import DefaultSyncDaysSetting
+from mhq.service.bookmark.bookmark import get_bookmark_service
+from mhq.utils.time import time_now
+
+app = Blueprint("bookmark", __name__)
+
+
+@app.route("/orgs/<org_id>/bookmark/reset", methods={"PUT"})
+@queryschema(
+    Schema(
+        {
+            Optional("bookmark_timestamp"): All(str, Coerce(datetime.fromisoformat)),
+        }
+    ),
+)
+def reset_bookmark(org_id: str, bookmark_timestamp: datetime = None):
+
+    query_validator = get_query_validator()
+    query_validator.org_validator(org_id)
+
+    if not bookmark_timestamp:
+
+        settings_service = get_settings_service()
+        default_sync_days_setting: DefaultSyncDaysSetting = (
+            settings_service.get_or_set_default_settings(
+                setting_type=SettingType.DEFAULT_SYNC_DAYS_SETTING,
+                entity_type=EntityType.ORG,
+                entity_id=org_id,
+            ).specific_settings
+        )
+
+        default_sync_days = default_sync_days_setting.default_sync_days
+        bookmark_timestamp = time_now() - timedelta(default_sync_days)
+
+    bookmark_service = get_bookmark_service()
+
+    bookmark_service.reset_org_bookmarks(org_id, bookmark_timestamp)
+
+    return {"updated_bookmark": bookmark_timestamp.isoformat()}


### PR DESCRIPTION
## Linked Issue(s) 

#500
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [x] Add API to reset bookmarks

## Proposed changes (including videos or screenshots)
- Added API to reset bookmarks.

`curl --location --request PUT 'http://localhost:9696/orgs/ac318840-5d88-451e-b3a5-355fa2a988d6/bookmark/reset'`

res:

```
{
    "updated_bookmark": "2024-07-08T19:49:01.602717+00:00"
}
```

- This api can be called to reset bookmarks after updating default sync days.
- Incase the default sync days setting API call fails, this wont be called.

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
