### PR TITLE
Gitlab org_name migration

### DIFF
--- a/backend/analytics_server/mhq/api/integrations.py
+++ b/backend/analytics_server/mhq/api/integrations.py
@@ -160,7 +160,7 @@ def get_gitlab_orgs(org_id: str):
                 "name": group.get("name"),
                 "avatar_url": group.get("avatar_url"),
                 "web_url": group.get("web_url"),
-                "internal_id": group.get("id"),
+                "provider_org_id": group.get("id"),
             }
             for group in groups
         ]

--- a/backend/analytics_server/mhq/service/code/sync/etl_gitlab_handler.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_gitlab_handler.py
@@ -106,7 +106,7 @@ class GitlabETLHandler(CodeProviderETLHandler):
             org_id=self.org_id,
             name=gitlab_repo.name,
             provider=self.provider,
-            org_name=org_repo.org_name,
+            org_name=gitlab_repo.org_name,
             default_branch=gitlab_repo.default_branch,
             language=str(gitlab_repo.languages),
             contributors=self.get_repo_contributors(gitlab_repo),


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
We ran into a problem where gitlab org_name was not being set properly for nested orgs and suborgs. 
And the frontend was making queries using group_name instead of group idempotent key (internal Id given by gitlab)

This PR sets the org name properly for nested orgs and sends group_id back to frontend for querying using that id
## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [ ] Task 1
- [ ] Task 2
- [ ] Task 3

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
