### PR TITLE
use full_path for org_name in org repos

### DIFF
--- a/backend/analytics_server/mhq/exapi/models/gitlab.py
+++ b/backend/analytics_server/mhq/exapi/models/gitlab.py
@@ -20,7 +20,7 @@ class GitlabRepo:
 
     def __init__(self, project: Dict):
         self.name = project.get("name")
-        self.org_name = project.get("namespace", {}).get("path")
+        self.org_name = project.get("namespace", {}).get("full_path")
         self.default_branch = project.get("default_branch")
         self.idempotency_key = str(project.get("id"))
         self.slug = project.get("path")


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if tis PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [ ] Task 1
- [ ] Task 2
- [ ] Task 3

## Proposed changes (including videos or screenshots)
Should save the entire org_name including subgroups and groups instead of saving the first ancestor for a repo. This has a change to violate the db constraint of unique org_name and repo_name for a provider. 
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
