### PR TITLE
fix: handle Caps Lock in CLI input to ensure correct command processing

### DIFF
--- a/cli/source/app.tsx
+++ b/cli/source/app.tsx
@@ -135,26 +135,28 @@ const CliUi = () => {
   }, [appState, exit]);
 
   useInput((input) => {
+    const lowerCaseInput = input.toLowerCase(); 
+
     if (appState === AppStates.DOCKER_READY) {
       dispatch(appSlice.actions.setLogsStream([]));
-      if (input === 'q') {
+      if (lowerCaseInput === 'q') {
         dispatch(appSlice.actions.setLogSource(LogSource.WebServer));
-      } else if (input === 'w') {
+      } else if (lowerCaseInput === 'w') {
         dispatch(appSlice.actions.setLogSource(LogSource.ApiServer));
-      } else if (input === 'e') {
+      } else if (lowerCaseInput === 'e') {
         dispatch(appSlice.actions.setLogSource(LogSource.Redis));
-      } else if (input === 'r') {
+      } else if (lowerCaseInput === 'r') {
         dispatch(appSlice.actions.setLogSource(LogSource.Postgres));
-      } else if (input === 't') {
+      } else if (lowerCaseInput === 't') {
         dispatch(appSlice.actions.setLogSource(LogSource.InitDb));
-      } else if (input === 'a') {
+      } else if (lowerCaseInput === 'a') {
         dispatch(appSlice.actions.setLogSource(LogSource.All));
-      } else if (input === 's') {
+      } else if (lowerCaseInput === 's') {
         dispatch(appSlice.actions.setLogSource(LogSource.SyncServer));
       }
     }
 
-    if (input === 'x') {
+    if (lowerCaseInput === 'x') {
       handleExit();
     }
   });


### PR DESCRIPTION
## Linked Issue(s) 

https://github.com/middlewarehq/middleware/issues/525

## Acceptance Criteria fulfillment



-  Case-Insensitive Input Handling: Updated the CLI's input handling to be case-insensitive by converting all user input to lowercase before processing. This ensures that the CLI recognizes commands regardless of whether Caps Lock is on or off.
-  Command Processing: Adjusted the command logic so that it consistently responds to inputs like 'x', 'q', 'w', etc., whether entered in uppercase or lowercase.

