### PR TITLE
download correct build of dbmate based on architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,16 @@ RUN apt-get update && \
     && echo "listen_addresses='*'" >> /etc/postgresql/15/main/postgresql.conf \
     && sed -i "s/^port = .*/port = ${DB_PORT}/" /etc/postgresql/15/main/postgresql.conf \
     && npm install --global yarn --force \
-    && curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-amd64 \
+    && if [ "$(uname -m)" = "x86_64" ]; then \
+         curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-amd64; \
+       elif [ "$(uname -m)" = "aarch64" ]; then \
+         curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-arm64; \
+       elif [ "$(uname -m)" = "arm64" ]; then \
+         curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-arm64; \
+       else \
+         echo "Unsupported architecture: $(uname -m)"; \
+         exit 1; \
+       fi \
     && chmod +x /usr/local/bin/dbmate \
     && mkdir -p /var/log/postgres \
     && touch /var/log/postgres/postgres.log \


### PR DESCRIPTION
## Linked Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
`amd64` build of dbmate was being installed even on `aarch64` architecture. This PR downloads the correct build of dbmate based on the architecture
## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [x] Shut down EC2 machine spawned for testing


## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
