### PR TITLE
exclude api/stream from nextjs trying to pre-render it which leads to timeouts

### DIFF
--- a/web-server/app/api/stream/route.ts
+++ b/web-server/app/api/stream/route.ts
@@ -205,3 +205,9 @@ export async function GET(): Promise<Response> {
     }
   });
 }
+
+// This line is necessary to prevent Next.js from attempting to statically generate this API route.
+// It forces the route to be dynamically rendered on each request, which is crucial for our
+// real-time streaming functionality. Without this, Next.js might try to pre-render the route
+// during build time, leading to timeouts or incorrect behavior.
+export const dynamic = "force-dynamic";


### PR DESCRIPTION

## Linked Issue(s)
Our last two builds failed because nextjs was trying to pre-render a route which was supposed to be dynamic. It would retry again and again and eventually timeout and fail. 

https://github.com/middlewarehq/middleware/actions/runs/10902707720/job/30255282669
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided. -->

- [ ] Task 1
- [ ] Task 2
- [ ] Task 3

## Proposed changes (including videos or screenshots)

We explicitly specify to nextjs that this is supposed to be a dynamic url and should be skipped from pre-rendering.
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
