### PR TITLE
Refactor GitLab validity check to include custom domain support

### DIFF
--- a/web-server/src/content/Dashboards/ConfigureGitlabModalBody.tsx
+++ b/web-server/src/content/Dashboards/ConfigureGitlabModalBody.tsx
@@ -48,10 +48,9 @@ export const ConfigureGitlabModalBody: FC<{
 
   const checkDomainWithRegex = (domain: string) => {
     const regex =
-      /^(https:\/\/)?[a-zA-Z0-9]+([-.][a-zA-Z0-9]+)*\.[a-zA-Z]{2,}(:[0-9]{1,5})?(\/.*)?$/;
+      /^(https?:\/\/)[a-zA-Z0-9]+([-.][a-zA-Z0-9]+)*\.[a-zA-Z]{2,}(:[0-9]{1,5})?(\/.*)?$/;
     return regex.test(domain);
   };
-
   const handleTokenChange = (e: string) => {
     token.set(e);
     showScopeError.set('');

--- a/web-server/src/content/Dashboards/ConfigureGitlabModalBody.tsx
+++ b/web-server/src/content/Dashboards/ConfigureGitlabModalBody.tsx
@@ -79,7 +79,7 @@ export const ConfigureGitlabModalBody: FC<{
     }
 
     depFn(isLoading.true);
-    await checkGitLabValidity(token.value)
+    await checkGitLabValidity(token.value, customDomain.value)
       .then(async (res) => {
         return res;
       })

--- a/web-server/src/utils/auth.ts
+++ b/web-server/src/utils/auth.ts
@@ -63,8 +63,14 @@ export const getMissingPATScopes = async (pat: string) => {
 
 // Gitlab functions
 
-export const checkGitLabValidity = async (accessToken: string) => {
-  const url = 'https://gitlab.com/api/v4/personal_access_tokens/self';
+export const checkGitLabValidity = async (
+  accessToken: string,
+  customDomain?: string
+) => {
+  const baseUrl = customDomain
+    ? `https://${customDomain}`
+    : 'https://gitlab.com';
+  const url = `${baseUrl}/api/v4/personal_access_tokens/self`;
   try {
     const response = await axios.get(url, {
       headers: {

--- a/web-server/src/utils/auth.ts
+++ b/web-server/src/utils/auth.ts
@@ -67,9 +67,7 @@ export const checkGitLabValidity = async (
   accessToken: string,
   customDomain?: string
 ) => {
-  const baseUrl = customDomain
-    ? `https://${customDomain}`
-    : 'https://gitlab.com';
+  const baseUrl = customDomain || 'https://gitlab.com';
   const url = `${baseUrl}/api/v4/personal_access_tokens/self`;
   try {
     const response = await axios.get(url, {


### PR DESCRIPTION
This pull request refactors the GitLab validity check to include support for custom domains. Previously, the validity check only worked with the default GitLab domain. With this change, users can now provide a custom domain for the validity check. The `checkGitLabValidity` function has been updated to accept an optional `customDomain` parameter, which allows users to specify their own GitLab domain. Additionally, the `ConfigureGitlabModalBody` component has been modified to include the `customDomain` value when calling the `checkGitLabValidity` function.