### PR TITLE
fix workflow name for building oss base docker image

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,4 +1,4 @@
-name: Publish Docker image
+name: Publish OSS Base Docker Image
 
 on:
   release:


### PR DESCRIPTION
## Linked Issue(s)
Currently the name of the workflow for building main docker image and the base docker image is same.
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Proposed changes (including videos or screenshots)
Rename the workflow which builds the base docker image
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
