### PR TITLE
Update readme web server setup to install node version 22.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ To set up middleware locally, follow these steps:
 
 6. **Web Server Setup**
 
-   - Install NodeJs 16.17 (LTS) either [manually](https://nodejs.org/en/download) or using a tool like [nvm](https://github.com/nvm-sh/nvm) or [volta](https://volta.sh/).
+   - Install NodeJs 22.x either [manually](https://nodejs.org/en/download) or using a tool like [nvm](https://github.com/nvm-sh/nvm) or [volta](https://volta.sh/).
 
    - Install `yarn` package manager
      ```bash


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file to reflect the new version requirement for NodeJs.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308-R308): Updated the NodeJs version requirement from 16.17 (LTS) to 22.x in the web server setup instructions.