### PR TITLE
allow searching for fork repos in github repo search

### DIFF
--- a/web-server/pages/api/internal/[org_id]/utils.ts
+++ b/web-server/pages/api/internal/[org_id]/utils.ts
@@ -102,7 +102,7 @@ export const searchGithubReposWithNames = async (
           }
       `;
 
-  const queryString = `${searchString} in:name`;
+  const queryString = `${searchString} in:name fork:true`;
 
   const response = await fetch(GITHUB_API_URL, {
     method: 'POST',


### PR DESCRIPTION
This pull request includes a small change to the `web-server/pages/api/internal/[org_id]/utils.ts` file. The change modifies the `queryString` to include forked repositories in the search results.

* `web-server/pages/api/internal/[org_id]/utils.ts`: Added `fork:true` to the `queryString` to include forked repositories in the GitHub search results. ([web-server/pages/api/internal/[org_id]/utils.tsL105-R105](diffhunk://#diff-d3bd3b2363c3dd42d9f9b6b36c12fe8c335040487a4ad190fa8f1d33f97e0c10L105-R105))