### PR TITLE
Fix deployment count display logic

### DIFF
--- a/web-server/src/content/DoraMetrics/DoraCards/WeeklyDeliveryVolumeCard.tsx
+++ b/web-server/src/content/DoraMetrics/DoraCards/WeeklyDeliveryVolumeCard.tsx
@@ -12,7 +12,6 @@ import {
   NoDataImg
 } from '@/content/DoraMetrics/DoraCards/sharedComponents';
 import { useAuth } from '@/hooks/useAuth';
-import { useCountUp } from '@/hooks/useCountUp';
 import {
   useCurrentDateRangeLabel,
   useStateDateConfig
@@ -55,10 +54,6 @@ export const WeeklyDeliveryVolumeCard = () => {
   const { integrationSet } = useAuth();
   const dateRangeLabel = useCurrentDateRangeLabel();
   const deploymentFrequencyProps = useAvgIntervalBasedDeploymentFrequency();
-
-  const deploymentFrequencyCount = useCountUp(
-    deploymentFrequencyProps.count || 0
-  );
 
   const { addPage } = useOverlayPage();
   const deploymentsConfigured = true;
@@ -209,11 +204,12 @@ export const WeeklyDeliveryVolumeCard = () => {
                     color={deploymentFrequencyProps.color}
                     sx={{ fontSize: '3em' }}
                   >
-                    {deploymentFrequencyProps.count ? (
-                      `${deploymentFrequencyCount}`
-                    ) : (
-                      <Line>No Deployments</Line>
-                    )}
+                    <Line>
+                      {getDeploymentCountString(
+                        deploymentFrequencyProps.count,
+                        totalDeployments
+                      )}
+                    </Line>
                   </Line>
                   {Boolean(
                     deploymentFrequencyProps.count ||
@@ -318,4 +314,12 @@ export const WeeklyDeliveryVolumeCard = () => {
       </FlexBox>
     </CardRoot>
   );
+};
+
+const getDeploymentCountString = (count: number, totalDeployments: number) => {
+  if (totalDeployments === 0) return 'No Deployments';
+  if (count) return `${count}`;
+
+  // backend doesn't send decimals, so if total deps exist, count cannot be zero, it's less than 1
+  return '<1';
 };


### PR DESCRIPTION
Update the deployment count display to correctly show "No Deployments" when there are no total deployments, ensuring accurate information is presented to the user.

<img width="709" alt="image" src="https://github.com/user-attachments/assets/fe4fbb2a-4df2-4f20-8d9a-389cb212b520" />

<img width="704" alt="image" src="https://github.com/user-attachments/assets/0dbb4393-dc00-42cb-868b-b13145208ff9" />

<img width="713" alt="image" src="https://github.com/user-attachments/assets/d3bb1969-513b-48b6-b85f-3fcce4f58028" />
