### PR TITLE
Reduce animation duration for count up effect

### DIFF
--- a/web-server/src/components/DoraMetricsConfigurationSettings.tsx
+++ b/web-server/src/components/DoraMetricsConfigurationSettings.tsx
@@ -53,7 +53,19 @@ export const DoraMetricsConfigurationSettings = () => {
           Settings
         </FlexBox>
       </Button>
-      <Menu anchorEl={anchorEl.current} open={open.value} onClose={open.false}>
+      <Menu
+        anchorEl={anchorEl.current}
+        open={open.value}
+        onClose={open.false}
+        MenuListProps={{
+          sx: {
+            padding: 0
+          }
+        }}
+        sx={{
+          padding: 0
+        }}
+      >
         <MenuItem
           onClick={() => {
             open.false();

--- a/web-server/src/content/DoraMetrics/DoraCards/ChangeFailureRateCard.tsx
+++ b/web-server/src/content/DoraMetrics/DoraCards/ChangeFailureRateCard.tsx
@@ -81,11 +81,7 @@ export const ChangeFailureRateCard = () => {
         .incident_count
   );
 
-  const changeFailureRateCount = useCountUp(
-    changeFailureRateProps.count || 0,
-    1500, // animation duration
-    2 // decimal place
-  );
+  const changeFailureRateCount = useCountUp(changeFailureRateProps.count || 0);
 
   const series = useMemo(
     () => [

--- a/web-server/src/hooks/useCountUp.ts
+++ b/web-server/src/hooks/useCountUp.ts
@@ -1,33 +1,32 @@
 import { useState, useEffect } from 'react';
 
-const FRAME_DURATION_MS = 16; // Average frame duration for 60fps
+const STEPS = 7; // number of steps to reach the target value
+const INTERVAL = 75; // in ms
 
 export const useCountUp = (
   targetValue: number,
-  duration: number = 1500,
   decimalPlaces: number = 0
 ): number => {
   const [count, setCount] = useState<number>(0);
 
   useEffect(() => {
-    let start = 0;
-    const increment = targetValue / (duration / FRAME_DURATION_MS);
+    let currentStep = 0;
+    const stepValue = targetValue / STEPS;
 
-    const animateCount = () => {
-      start += increment;
+    const timer = setInterval(() => {
+      currentStep++;
 
-      if (start >= targetValue) {
+      if (currentStep >= STEPS) {
         setCount(parseFloat(targetValue.toFixed(decimalPlaces)));
+        clearInterval(timer);
       } else {
-        setCount(parseFloat(start.toFixed(decimalPlaces)));
-        requestAnimationFrame(animateCount);
+        const newValue = stepValue * currentStep;
+        setCount(parseFloat(newValue.toFixed(decimalPlaces)));
       }
-    };
+    }, INTERVAL);
 
-    animateCount();
-
-    return () => {};
-  }, [targetValue, duration, decimalPlaces]);
+    return () => clearInterval(timer);
+  }, [targetValue, decimalPlaces]);
 
   return count;
 };


### PR DESCRIPTION
1. Shorten the animation duration in the count up effect by removing the duration parameter and implementing a fixed step-based approach.

## Before:
https://github.com/user-attachments/assets/118c9c40-ca0a-468e-abff-635b084cfb02

## Now:
https://github.com/user-attachments/assets/b47729d2-eaa4-4200-a0db-cc4f67ebbaf5

2. Fixes fat menu padding

<img width="320" alt="image" src="https://github.com/user-attachments/assets/8ba49950-cbf2-483a-93f6-c5f4e5ebfa08" /> <img width="339" alt="image" src="https://github.com/user-attachments/assets/ba02c13a-1afe-4af9-8da3-d6cdc735353c" />
