### PR TITLE
Fix PR cycle time calculation for draft PRs

### DIFF
--- a/backend/analytics_server/mhq/exapi/github.py
+++ b/backend/analytics_server/mhq/exapi/github.py
@@ -114,9 +114,13 @@ class GithubApiService:
     def get_pr_reviews(self, pr: GithubPullRequest) -> GithubPaginatedList:
         return pr.get_reviews()
     
-    def get_pr_timeline(self, github_repo:GithubRepository, pr_number:int):
-            issue = github_repo.get_issue(pr_number)
-            return issue.get_timeline()
+    def get_pr_timeline(self, org_login:str,repo_name:str, pr_number:int):
+            github_url = f"{self.base_url}/repos/{org_login}/{repo_name}/issues/{pr_number}/timeline"
+            response = requests.get(
+                github_url, headers=self.headers    
+                )
+            assert response.status_code == HTTPStatus.OK
+            return response.json()
 
     def get_contributors(
         self, org_login: str, repo_name: str

--- a/backend/analytics_server/mhq/exapi/github.py
+++ b/backend/analytics_server/mhq/exapi/github.py
@@ -113,14 +113,16 @@ class GithubApiService:
 
     def get_pr_reviews(self, pr: GithubPullRequest) -> GithubPaginatedList:
         return pr.get_reviews()
-    
-    def get_pr_timeline(self, org_login:str,repo_name:str, pr_number:int):
-            github_url = f"{self.base_url}/repos/{org_login}/{repo_name}/issues/{pr_number}/timeline"
-            response = requests.get(
-                github_url, headers=self.headers    
-                )
-            assert response.status_code == HTTPStatus.OK
-            return response.json()
+
+    def get_pr_timeline(
+        self, org_login: str, repo_name: str, pr_number: int
+    ) -> List[Dict]:
+        github_url = (
+            f"{self.base_url}/repos/{org_login}/{repo_name}/issues/{pr_number}/timeline"
+        )
+        response = requests.get(github_url, headers=self.headers)
+        assert response.status_code == HTTPStatus.OK
+        return response.json()
 
     def get_contributors(
         self, org_login: str, repo_name: str

--- a/backend/analytics_server/mhq/exapi/github.py
+++ b/backend/analytics_server/mhq/exapi/github.py
@@ -113,6 +113,10 @@ class GithubApiService:
 
     def get_pr_reviews(self, pr: GithubPullRequest) -> GithubPaginatedList:
         return pr.get_reviews()
+    
+    def get_pr_timeline(self, github_repo:GithubRepository, pr_number:int):
+            issue = github_repo.get_issue(pr_number)
+            return issue.get_timeline()
 
     def get_contributors(
         self, org_login: str, repo_name: str

--- a/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
@@ -92,7 +92,7 @@ class CodeETLAnalyticsService:
             pr_earliest_event
             if pr_earliest_event and isinstance(pr_earliest_event, datetime)
             else pr.created_at
-        ).astimezone(timezone.utc)
+        )
 
         cycle_time = pr.state_changed_at - first_open_time
 

--- a/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
@@ -54,20 +54,6 @@ class CodeETLAnalyticsService:
     @staticmethod
     def get_pr_performance(pr: PullRequest, pr_events: [PullRequestEvent]):
         pr_events.sort(key=lambda x: x.created_at)
-
-        first_ready_event = next(
-            (
-                e
-                for e in pr_events
-                if e.data.get("state") == PullRequestState.OPEN.value
-            ),
-            None,
-        )
-
-        first_open_time = (
-            first_ready_event.created_at if first_ready_event else pr.created_at
-        )
-
         first_review = pr_events[0] if pr_events else None
         approved_reviews = list(
             filter(
@@ -101,8 +87,7 @@ class CodeETLAnalyticsService:
             # Prevent garbage state when PR is approved post merging
             merge_time = -1 if merge_time < 0 else merge_time
 
-        cycle_time = pr.state_changed_at - first_open_time
-
+        cycle_time = pr.state_changed_at - pr.created_at
         if isinstance(cycle_time, timedelta):
             cycle_time = cycle_time.total_seconds()
 

--- a/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
@@ -1,5 +1,5 @@
-from datetime import datetime,timedelta,timezone
-from typing import List,Optional
+from datetime import datetime, timedelta
+from typing import List, Optional
 
 from mhq.service.code.sync.models import PRPerformance
 from mhq.store.models.code import (
@@ -10,7 +10,6 @@ from mhq.store.models.code import (
     PullRequestState,
 )
 from mhq.utils.time import Interval
-from mhq.utils.log import LOG
 
 
 class CodeETLAnalyticsService:
@@ -19,12 +18,11 @@ class CodeETLAnalyticsService:
         pr: PullRequest,
         pr_events: List[PullRequestEvent],
         pr_commits: List[PullRequestCommit],
-        pr_earliest_event:Optional[datetime]
+        pr_earliest_event: Optional[datetime],
     ) -> PullRequest:
         if pr.state == PullRequestState.OPEN:
             return pr
-
-        pr_performance = self.get_pr_performance(pr, pr_events,pr_earliest_event)
+        pr_performance = self.get_pr_performance(pr, pr_events, pr_earliest_event)
 
         pr.first_response_time = (
             pr_performance.first_review_time
@@ -54,10 +52,11 @@ class CodeETLAnalyticsService:
         return pr
 
     @staticmethod
-    def get_pr_performance(pr: PullRequest, pr_events: [PullRequestEvent],pr_earliest_event:Optional[datetime]):
-        LOG.info(
-            f"Calculating PR performance for {pr.id} with {len(pr_events)} events"
-        )
+    def get_pr_performance(
+        pr: PullRequest,
+        pr_events: [PullRequestEvent],
+        pr_earliest_event: Optional[datetime],
+    ):
         pr_events.sort(key=lambda x: x.created_at)
         first_review = pr_events[0] if pr_events else None
         approved_reviews = list(
@@ -98,13 +97,6 @@ class CodeETLAnalyticsService:
         )
 
         cycle_time = pr.state_changed_at - first_open_time
-
-        LOG.info( 
-            f"PR {pr.id} performance: "
-            f"rework_time={rework_time}, "
-            f"merge_time={merge_time}, "
-            f"cycle_time={cycle_time}"
-        )
 
         if isinstance(cycle_time, timedelta):
             cycle_time = cycle_time.total_seconds()

--- a/backend/analytics_server/mhq/service/code/sync/etl_github_handler.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_github_handler.py
@@ -30,6 +30,7 @@ from mhq.store.repos.code import CodeRepoService
 from mhq.store.repos.core import CoreRepoService
 from mhq.utils.log import LOG
 from mhq.utils.time import time_now, ISO_8601_DATE_FORMAT
+from types import SimpleNamespace
 
 PR_PROCESSING_CHUNK_SIZE = 100
 
@@ -147,7 +148,7 @@ class GithubETLHandler(CodeProviderETLHandler):
                 continue
 
             pr_model, event_models, pr_commit_models = self.process_pr(
-                str(org_repo.id), github_pr, github_repo
+                str(org_repo.id), github_pr, org_repo.org_name, org_repo.name
             )
             pull_requests.append(pr_model)
             pr_events += event_models
@@ -157,7 +158,7 @@ class GithubETLHandler(CodeProviderETLHandler):
         return pull_requests, pr_commits, pr_events
 
     def process_pr(
-        self, repo_id: str, pr: GithubPullRequest,github_repo:GithubRepository
+        self, repo_id: str, pr: GithubPullRequest, org_name:str, org_repo:str
     ) -> Tuple[PullRequest, List[PullRequestEvent], List[PullRequestCommit]]:
         pr_model: Optional[PullRequest] = self.code_repo_service.get_repo_pr_by_number(
             repo_id, pr.number
@@ -172,7 +173,7 @@ class GithubETLHandler(CodeProviderETLHandler):
         pr_events_model_list: List[PullRequestEvent] = self._to_pr_events(
             reviews, pr_model, pr_event_model_list
         )
-        pr_timeline_events=self._api.get_pr_timeline(github_repo,pr.number)
+        pr_timeline_events=self._api.get_pr_timeline(org_name,org_repo,pr.number)
         pr_earliest_ready_for_review= self.get_first_ready_for_review_event(pr_timeline_events)
         if pr.merged_at:
             commits: List[Dict] = list(
@@ -190,22 +191,34 @@ class GithubETLHandler(CodeProviderETLHandler):
 
         return pr_model, pr_events_model_list, pr_commits_model_list
     
-    def get_first_ready_for_review_event(self, events: List) -> Optional[datetime]:
+    def get_first_ready_for_review_event(self, timeline: List[Dict]) -> Optional[datetime]:
         """
         Find the earliest 'ready_for_review' event from a list of PR timeline events.
-        params:
-            events: List of PR timeline events
-        returns:
+        
+        Args:
+            timeline: List of PR timeline events
+            
+        Returns:
             The earliest ready_for_review event's datetime or None if no such event exists
         """
-        ready_events = [
-            event for event in events
-            if getattr(event, "event", None) == "ready_for_review" and hasattr(event, "created_at")
-        ]
+        ready_events = []
+        for event in timeline:
+            if event.get("event") == "ready_for_review" and "created_at" in event:
+                try:
+                    created_at = datetime.fromisoformat(
+                        event["created_at"].replace("Z", "+00:00")
+                    )
+                    ready_events.append(SimpleNamespace(created_at=created_at))
+                except (ValueError, KeyError):
+                    continue
+        
         if not ready_events:
             return None
         
         earliest_event = min(ready_events, key=lambda e: e.created_at)
+        LOG.info(
+            f"Found earliest ready_for_review event: {earliest_event.created_at}"
+        )
         return earliest_event.created_at.astimezone(pytz.UTC)
     
     def get_revert_prs_mapping(

--- a/backend/analytics_server/mhq/service/code/sync/etl_github_handler.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_github_handler.py
@@ -206,7 +206,7 @@ class GithubETLHandler(CodeProviderETLHandler):
             return None
         
         earliest_event = min(ready_events, key=lambda e: e.created_at)
-        return earliest_event.created_at
+        return earliest_event.created_at.astimezone(pytz.UTC)
     
     def get_revert_prs_mapping(
         self, prs: List[PullRequest]

--- a/backend/analytics_server/mhq/service/code/sync/etl_github_handler.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_github_handler.py
@@ -185,21 +185,28 @@ class GithubETLHandler(CodeProviderETLHandler):
             )
 
         pr_model = self.code_etl_analytics_service.create_pr_metrics(
-            pr_model, pr_events_model_list, pr_commits_model_list,pr_earliest_ready_for_review
+            pr_model, pr_events_model_list, pr_commits_model_list, pr_earliest_ready_for_review
         )
 
         return pr_model, pr_events_model_list, pr_commits_model_list
     
-    @staticmethod
-    def get_first_ready_for_review_event(events: List) -> Optional[object]:
+    def get_first_ready_for_review_event(self, events: List) -> Optional[datetime]:
+        """
+        Find the earliest 'ready_for_review' event from a list of PR timeline events.
+        params:
+            events: List of PR timeline events
+        returns:
+            The earliest ready_for_review event's datetime or None if no such event exists
+        """
         ready_events = [
             event for event in events
             if getattr(event, "event", None) == "ready_for_review" and hasattr(event, "created_at")
         ]
         if not ready_events:
             return None
+        
         earliest_event = min(ready_events, key=lambda e: e.created_at)
-        return earliest_event
+        return earliest_event.created_at
     
     def get_revert_prs_mapping(
         self, prs: List[PullRequest]

--- a/backend/analytics_server/tests/service/code/sync/test_etl_code_analytics.py
+++ b/backend/analytics_server/tests/service/code/sync/test_etl_code_analytics.py
@@ -9,6 +9,8 @@ from tests.factories.models.code import (
     get_pull_request_commit,
 )
 
+# Updated code with None as the third argument in get_pr_performance calls
+
 
 def test_pr_performance_returns_first_review_tat_for_first_review():
     pr_service = CodeETLAnalyticsService()
@@ -16,14 +18,14 @@ def test_pr_performance_returns_first_review_tat_for_first_review():
     t2 = t1 + timedelta(hours=1)
     pr = get_pull_request(created_at=t1, updated_at=t1)
     pr_event = get_pull_request_event(pull_request_id=pr.id, created_at=t2)
-    performance = pr_service.get_pr_performance(pr, [pr_event])
+    performance = pr_service.get_pr_performance(pr, [pr_event], None)
     assert performance.first_review_time == 3600
 
 
 def test_pr_performance_returns_minus1_first_review_tat_for_no_reviews():
     pr_service = CodeETLAnalyticsService()
     pr = get_pull_request()
-    performance = pr_service.get_pr_performance(pr, [])
+    performance = pr_service.get_pr_performance(pr, [], None)
     assert performance.first_review_time == -1
 
 
@@ -35,7 +37,7 @@ def test_pr_performance_returns_minus1_first_approved_review_tat_for_no_approved
     pr_event_1 = get_pull_request_event(
         pull_request_id=pr.id, state="REJECTED", created_at=t2
     )
-    performance = pr_service.get_pr_performance(pr, [pr_event_1])
+    performance = pr_service.get_pr_performance(pr, [pr_event_1], None)
     assert performance.merge_time == -1
 
 
@@ -46,7 +48,7 @@ def test_pr_performance_returns_merge_time_minus1_for_merged_pr_without_review()
     pr = get_pull_request(
         state=PullRequestState.MERGED, state_changed_at=t2, created_at=t1, updated_at=t2
     )
-    performance = pr_service.get_pr_performance(pr, [])
+    performance = pr_service.get_pr_performance(pr, [], None)
     assert performance.merge_time == -1
 
 
@@ -61,7 +63,7 @@ def test_pr_performance_returns_blocking_reviews():
         created_at=t1,
         updated_at=t2,
     )
-    performance = pr_service.get_pr_performance(pr, [])
+    performance = pr_service.get_pr_performance(pr, [], None)
     assert performance.blocking_reviews == 0
 
 
@@ -88,7 +90,7 @@ def test_pr_performance_returns_rework_time():
         pull_request_id=pr.id, state=PullRequestEventState.APPROVED.value, created_at=t4
     )
     performance = pr_service.get_pr_performance(
-        pr, [changes_requested_1, comment2, approval]
+        pr, [changes_requested_1, comment2, approval], None
     )
 
     assert performance.rework_time == (t4 - t2).total_seconds()
@@ -104,7 +106,7 @@ def test_pr_performance_returns_rework_time_0_for_approved_prs():
     approval = get_pull_request_event(
         pull_request_id=pr.id, state=PullRequestEventState.APPROVED.value, created_at=t2
     )
-    performance = pr_service.get_pr_performance(pr, [approval])
+    performance = pr_service.get_pr_performance(pr, [approval], None)
 
     assert performance.rework_time == 0
 
@@ -130,7 +132,7 @@ def test_pr_performance_returns_rework_time_as_per_first_approved_prs():
         pull_request_id=pr.id, state=PullRequestEventState.APPROVED.value, created_at=t4
     )
     performance = pr_service.get_pr_performance(
-        pr, [changes_requested_1, approval, approval_2]
+        pr, [changes_requested_1, approval, approval_2], None
     )
 
     assert performance.rework_time == (t3 - t2).total_seconds()
@@ -150,7 +152,9 @@ def test_pr_performance_returns_rework_time_for_open_prs():
     approval = get_pull_request_event(
         pull_request_id=pr.id, state=PullRequestEventState.APPROVED.value, created_at=t3
     )
-    performance = pr_service.get_pr_performance(pr, [changes_requested_1, approval])
+    performance = pr_service.get_pr_performance(
+        pr, [changes_requested_1, approval], None
+    )
 
     assert performance.rework_time == (t3 - t2).total_seconds()
 
@@ -165,7 +169,7 @@ def test_pr_performance_returns_rework_time_minus1_for_non_approved_prs():
         state=PullRequestEventState.CHANGES_REQUESTED.value,
         created_at=t2,
     )
-    performance = pr_service.get_pr_performance(pr, [changes_requested_1])
+    performance = pr_service.get_pr_performance(pr, [changes_requested_1], None)
 
     assert performance.rework_time == -1
 
@@ -176,7 +180,7 @@ def test_pr_performance_returns_rework_time_minus1_for_merged_prs_without_review
     pr = get_pull_request(
         state=PullRequestState.MERGED, state_changed_at=t1, created_at=t1, updated_at=t1
     )
-    performance = pr_service.get_pr_performance(pr, [])
+    performance = pr_service.get_pr_performance(pr, [], None)
 
     assert performance.rework_time == -1
 
@@ -188,7 +192,7 @@ def test_pr_performance_returns_cycle_time_for_merged_pr():
     pr = get_pull_request(
         state=PullRequestState.MERGED, state_changed_at=t2, created_at=t1, updated_at=t2
     )
-    performance = pr_service.get_pr_performance(pr, [])
+    performance = pr_service.get_pr_performance(pr, [], None)
 
     assert performance.cycle_time == 86400
 
@@ -196,7 +200,7 @@ def test_pr_performance_returns_cycle_time_for_merged_pr():
 def test_pr_performance_returns_cycle_time_minus1_for_non_merged_pr():
     pr_service = CodeETLAnalyticsService()
     pr = get_pull_request()
-    performance = pr_service.get_pr_performance(pr, [])
+    performance = pr_service.get_pr_performance(pr, [], None)
 
     assert performance.cycle_time == -1
 

--- a/backend/analytics_server/tests/service/code/sync/test_etl_github_handler.py
+++ b/backend/analytics_server/tests/service/code/sync/test_etl_github_handler.py
@@ -346,20 +346,16 @@ def test__to_pr_commits_given_a_list_of_commits_returns_a_list_of_pr_commits():
     for commit, expected_commit in zip(pr_commits, expected_pr_commits):
         assert compare_objects_as_dicts(commit, expected_commit) is True
 
-def test_get_first_ready_for_review_event_returns_earliest_ready_event():
-    class MockTimelineEvent:
-        def __init__(self, event_type, created_at):
-            self.event = event_type
-            self.created_at = created_at
 
+def test_get_first_ready_for_review_event_returns_earliest_ready_event():
     earlier_date = datetime(2024, 1, 1, 10, 0, 0, tzinfo=pytz.UTC)
     later_date = datetime(2024, 1, 2, 10, 0, 0, tzinfo=pytz.UTC)
 
     events = [
-        MockTimelineEvent("other_event", earlier_date),
-        MockTimelineEvent("ready_for_review", later_date),
-        MockTimelineEvent("ready_for_review", earlier_date),
-        MockTimelineEvent("another_event", later_date),
+        {"event": "other_event", "created_at": earlier_date},
+        {"event": "ready_for_review", "created_at": later_date},
+        {"event": "ready_for_review", "created_at": earlier_date},
+        {"event": "another_event", "created_at": later_date},
     ]
 
     github_etl_handler = GithubETLHandler(ORG_ID, None, None, None, None)
@@ -367,16 +363,12 @@ def test_get_first_ready_for_review_event_returns_earliest_ready_event():
 
     assert result == earlier_date
 
-def test_get_first_ready_for_review_event_returns_none_when_no_ready_events():
-    class MockTimelineEvent:
-        def __init__(self, event_type, created_at):
-            self.event = event_type
-            self.created_at = created_at
 
+def test_get_first_ready_for_review_event_returns_none_when_no_ready_events():
     date = datetime(2024, 1, 1, 10, 0, 0, tzinfo=pytz.UTC)
     events = [
-        MockTimelineEvent("other_event", date),
-        MockTimelineEvent("another_event", date),
+        {"event": "other_event", "created_at": date},
+        {"event": "another_event", "created_at": date},
     ]
 
     github_etl_handler = GithubETLHandler(ORG_ID, None, None, None, None)
@@ -384,13 +376,9 @@ def test_get_first_ready_for_review_event_returns_none_when_no_ready_events():
 
     assert result is None
 
+
 def test_get_first_ready_for_review_event_handles_empty_list():
     github_etl_handler = GithubETLHandler(ORG_ID, None, None, None, None)
     result = github_etl_handler.get_first_ready_for_review_event([])
 
     assert result is None
-
-def test__dt_from_github_dt_string_given_date_string_returns_correct_datetime():
-    date_string = "2024-04-18T10:53:15Z"
-    expected = datetime(2024, 4, 18, 10, 53, 15, tzinfo=pytz.UTC)
-    assert GithubETLHandler._dt_from_github_dt_string(date_string) == expected

--- a/backend/analytics_server/tests/service/code/sync/test_etl_github_handler.py
+++ b/backend/analytics_server/tests/service/code/sync/test_etl_github_handler.py
@@ -352,23 +352,27 @@ def test_get_first_ready_for_review_event_returns_earliest_ready_event():
     later_date = datetime(2024, 1, 2, 10, 0, 0, tzinfo=pytz.UTC)
 
     events = [
-        {"event": "other_event", "created_at": earlier_date},
-        {"event": "ready_for_review", "created_at": later_date},
-        {"event": "ready_for_review", "created_at": earlier_date},
-        {"event": "another_event", "created_at": later_date},
+        {"event": "other_event", "created_at": earlier_date.isoformat()},
+        {"event": "ready_for_review", "created_at": later_date.isoformat()},
+        {"event": "ready_for_review", "created_at": earlier_date.isoformat()},
+        {"event": "another_event", "created_at": later_date.isoformat()},
     ]
 
     github_etl_handler = GithubETLHandler(ORG_ID, None, None, None, None)
     result = github_etl_handler.get_first_ready_for_review_event(events)
 
-    assert result == earlier_date
+    # The method should parse the string date back to a datetime object
+    expected_date = datetime.fromisoformat(
+        earlier_date.isoformat().replace("Z", "+00:00")
+    )
+    assert result == expected_date
 
 
 def test_get_first_ready_for_review_event_returns_none_when_no_ready_events():
     date = datetime(2024, 1, 1, 10, 0, 0, tzinfo=pytz.UTC)
     events = [
-        {"event": "other_event", "created_at": date},
-        {"event": "another_event", "created_at": date},
+        {"event": "other_event", "created_at": date.isoformat()},
+        {"event": "another_event", "created_at": date.isoformat()},
     ]
 
     github_etl_handler = GithubETLHandler(ORG_ID, None, None, None, None)


### PR DESCRIPTION
This pull request includes several changes to enhance the processing and analysis of pull requests in the `backend/analytics_server` module. The key changes include adding a method to retrieve the pull request timeline, updating the `create_pr_metrics` function to account for the earliest "ready for review" event, and modifying the `process_pr` function to incorporate this new data.

Enhancements to pull request processing:

* [`backend/analytics_server/mhq/exapi/github.py`](diffhunk://#diff-5d36f4b8885af43c9d0276ad9fd282bbeefd7e1d4a7cf5857f007b6f312b113fR117-R120): Added a new method `get_pr_timeline` to retrieve the timeline of a pull request.

Updates to metrics calculation:

* [`backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py`](diffhunk://#diff-517b77ebf07ce3d53443b38b360b0bac87cfb171088de3a18857184b1ec15b27R21-R26): Updated the `create_pr_metrics` function to include an optional `pr_earliest_event` parameter and adjusted the `get_pr_performance` function to use this parameter for calculating the cycle time. [[1]](diffhunk://#diff-517b77ebf07ce3d53443b38b360b0bac87cfb171088de3a18857184b1ec15b27R21-R26) [[2]](diffhunk://#diff-517b77ebf07ce3d53443b38b360b0bac87cfb171088de3a18857184b1ec15b27L55-R56) [[3]](diffhunk://#diff-517b77ebf07ce3d53443b38b360b0bac87cfb171088de3a18857184b1ec15b27L90-R98)

Changes to pull request processing flow:

* [`backend/analytics_server/mhq/service/code/sync/etl_github_handler.py`](diffhunk://#diff-69397c85053232fad42cdda40df02c93514c9f8bd688a9f3588f7c3374988cb8L150-R150): Modified the `process_pr` function to call the new `get_pr_timeline` method and retrieve the earliest "ready for review" event for use in metrics calculation. [[1]](diffhunk://#diff-69397c85053232fad42cdda40df02c93514c9f8bd688a9f3588f7c3374988cb8L150-R150) [[2]](diffhunk://#diff-69397c85053232fad42cdda40df02c93514c9f8bd688a9f3588f7c3374988cb8L160-R160) [[3]](diffhunk://#diff-69397c85053232fad42cdda40df02c93514c9f8bd688a9f3588f7c3374988cb8R175-R176) [[4]](diffhunk://#diff-69397c85053232fad42cdda40df02c93514c9f8bd688a9f3588f7c3374988cb8L186-R210)

Additional imports:

* [`backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py`](diffhunk://#diff-517b77ebf07ce3d53443b38b360b0bac87cfb171088de3a18857184b1ec15b27L1-R2): Added `datetime` and `timezone` to the imports to handle timezone-aware datetime objects.
## Linked Issue(s)

Resolves issue #634 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new optional parameter for pull request metrics to enhance cycle time calculations.
  - Added a method to retrieve pull request timelines directly from the GitHub API.
  - Enhanced pull request processing with additional metrics related to readiness.

- **Tests**
  - Added new tests to ensure the correct functionality of the readiness event retrieval method under various conditions.
  - Updated existing tests to accommodate changes in performance metric calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->