### PR TITLE
feat(teams): enhance TeamCard with repository display and improved styling

### DIFF
--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -211,30 +211,26 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
 
   const renderVisibleRepos = (
     <FlexBox alignCenter gap={1}>
-      <AvatarGroup 
-        max={VISIBLE_REPOS_COUNT} 
-        sx={{ 
+      <AvatarGroup
+        max={VISIBLE_REPOS_COUNT}
+        sx={{
           marginRight: 1,
-          '& .MuiAvatar-root': { 
+          '& .MuiAvatar-root': {
             border: '1px solid #f0f0f0',
-            width: 28, 
-            height: 28 
+            width: 28,
+            height: 28
           }
         }}
       >
         {visibleReposName.map((repo) => (
-          <Avatar 
-            key={repo.id || repo.name} 
-            src={`https://github.com/${repo.org_name}.png?size=20`}
+          <Avatar
+            key={repo.id || repo.name}
+            src={`https://github.com/${repo.org_name}.png?size=28`}
           />
         ))}
       </AvatarGroup>
       <Line secondary sx={{ fontSize: '0.85rem' }}>
-        {visibleReposName.map((repo, index) => (
-          <span key={repo.id || repo.name}>
-            {repo.name}{index < visibleReposName.length - 1 ? ', ' : ''}
-          </span>
-        ))}
+        {visibleReposName.map(repo => repo.name).join(', ')}
       </Line>
     </FlexBox>
   );
@@ -253,31 +249,31 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
   }, [teamName]);
 
   return (
-    <FlexBox 
-      component={Card} 
-      p={2.5} 
-      minHeight={'150px'} 
-      sx={{ 
+    <FlexBox
+      component={Card}
+      p={2.5}
+      minHeight={'150px'}
+      sx={{
         borderRadius: '8px',
         boxShadow: '0 2px 10px rgba(0,0,0,0.08)',
         '&:hover': { boxShadow: '0 4px 12px rgba(0,0,0,0.12)' }
       }}
-        >
+    >
       <FlexBox fullWidth col gap={2} flex={1}>
         <FlexBox justifyBetween alignCenter>
           <FlexBox
-        title={minifiedName === teamName ? null : teamName}
-        tooltipPlacement="right"
-        alignCenter
-        gap={1}
+            title={minifiedName === teamName ? null : teamName}
+            tooltipPlacement="right"
+            alignCenter
+            gap={1}
           >
-        <Line big semibold sx={{ color: 'primary.dark' }}>
-          {minifiedName}
-        </Line>
+            <Line big semibold sx={{ color: 'primary.dark' }}>
+              {minifiedName}
+            </Line>
           </FlexBox>
           <FlexBox gap={1}>
-        <EditTeam teamId={teamId} onEdit={onEdit} />
-        <MoreOptions teamId={team.id} />
+            <EditTeam teamId={teamId} onEdit={onEdit} />
+            <MoreOptions teamId={team.id} />
           </FlexBox>
         </FlexBox>
 
@@ -285,48 +281,48 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
 
         <FlexBox col gap={2} flex={1}>
           <FlexBox gap={1} alignCenter>
-        <Line bigish bold sx={{ color: 'text.primary' }}>
-          {assignedReposToTeam.length}{' '}
-          {pluralize('Repository', assignedReposToTeam.length)}
-        </Line>
+            <Line bigish bold sx={{ color: 'text.primary' }}>
+              {assignedReposToTeam.length}{' '}
+              {pluralize('Repository', assignedReposToTeam.length)}
+            </Line>
           </FlexBox>
 
           {Boolean(assignedReposToTeam.length) && (
-        <FlexBox col gap={1}>
-          {renderVisibleRepos}
-          
-          {assignedReposToTeam.length > VISIBLE_REPOS_COUNT && (
-            <FlexBox
-          inline
-          sx={{
-            userSelect: 'none',
-            ml: 1
-          }}
-          title={
-            <FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>
-          }
-            >
-          <Line info>
-            +{assignedReposToTeam.length - VISIBLE_REPOS_COUNT} more
-          </Line>
+            <FlexBox col gap={1}>
+              {renderVisibleRepos}
+
+              {assignedReposToTeam.length > VISIBLE_REPOS_COUNT && (
+                <FlexBox
+                  inline
+                  sx={{
+                    userSelect: 'none',
+                    ml: 1
+                  }}
+                  title={
+                    <FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>
+                  }
+                >
+                  <Line info>
+                    +{assignedReposToTeam.length - VISIBLE_REPOS_COUNT} more
+                  </Line>
+                </FlexBox>
+              )}
             </FlexBox>
-          )}
-        </FlexBox>
           )}
         </FlexBox>
 
         <FlexBox justifyCenter mt={1}>
           <Button
-        sx={{ width: '100%' }}
-        variant="contained"
-        onClick={() => onView(team)}
-        startIcon={<DoraIcon style={{ width: 20, height: 20 }} />}
+            sx={{ width: '100%' }}
+            variant="contained"
+            onClick={() => onView(team)}
+            startIcon={<DoraIcon style={{ width: 20, height: 20 }} />}
           >
-        View DORA Metrics
+            View DORA Metrics
           </Button>
         </FlexBox>
       </FlexBox>
-        </FlexBox>
+    </FlexBox>
   );
 
 };

--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -230,7 +230,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
         ))}
       </AvatarGroup>
       <Line secondary sx={{ fontSize: '0.85rem' }}>
-        {visibleReposName.map(repo => repo.name).join(', ')}
+        {visibleReposName.map((repo) => repo.name).join(', ')}
       </Line>
     </FlexBox>
   );
@@ -298,9 +298,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
                     userSelect: 'none',
                     ml: 1
                   }}
-                  title={
-                    <FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>
-                  }
+                  title={<FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>}
                 >
                   <Line info>
                     +{assignedReposToTeam.length - VISIBLE_REPOS_COUNT} more

--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -296,11 +296,12 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
                   inline
                   sx={{
                     userSelect: 'none',
-                    ml: 1
+                    mr: 20
+
                   }}
                   title={<FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>}
                 >
-                  <Line info>
+                  <Line info sx={{ ml: 10 }}>
                     +{assignedReposToTeam.length - VISIBLE_REPOS_COUNT} more
                   </Line>
                 </FlexBox>

--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -1,8 +1,11 @@
+
 import { Add, Delete, Edit, MoreVert } from '@mui/icons-material';
 import {
   Button,
   Card,
   Divider,
+  Avatar,
+  AvatarGroup,
   Menu,
   MenuItem,
   TextField
@@ -206,6 +209,36 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
   );
   const visibleReposName = assignedReposToTeam.slice(0, VISIBLE_REPOS_COUNT);
 
+  const renderVisibleRepos = (
+    <FlexBox alignCenter gap={1}>
+      <AvatarGroup 
+        max={VISIBLE_REPOS_COUNT} 
+        sx={{ 
+          marginRight: 1,
+          '& .MuiAvatar-root': { 
+            border: '1px solid #f0f0f0',
+            width: 28, 
+            height: 28 
+          }
+        }}
+      >
+        {visibleReposName.map((repo) => (
+          <Avatar 
+            key={repo.id || repo.name} 
+            src={`https://github.com/${repo.org_name}.png?size=20`}
+          />
+        ))}
+      </AvatarGroup>
+      <Line secondary sx={{ fontSize: '0.85rem' }}>
+        {visibleReposName.map((repo, index) => (
+          <span key={repo.id || repo.name}>
+            {repo.name}{index < visibleReposName.length - 1 ? ', ' : ''}
+          </span>
+        ))}
+      </Line>
+    </FlexBox>
+  );
+
   const tooltipRepos = useMemo(
     () =>
       assignedReposToTeam
@@ -220,74 +253,82 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
   }, [teamName]);
 
   return (
-    <FlexBox component={Card} p={2} minHeight={'144px'} gap2>
-      <FlexBox fullWidth col gap2 justifyBetween>
-        <FlexBox col gap2>
-          <FlexBox justifyBetween alignStart>
-            <FlexBox
-              title={minifiedName === teamName ? null : teamName}
-              tooltipPlacement="right"
-            >
-              <Line big semibold>
-                {minifiedName}
-              </Line>
-            </FlexBox>
+    <FlexBox 
+      component={Card} 
+      p={2.5} 
+      minHeight={'150px'} 
+      sx={{ 
+        borderRadius: '8px',
+        boxShadow: '0 2px 10px rgba(0,0,0,0.08)',
+        '&:hover': { boxShadow: '0 4px 12px rgba(0,0,0,0.12)' }
+      }}
+        >
+      <FlexBox fullWidth col gap={2} flex={1}>
+        <FlexBox justifyBetween alignCenter>
+          <FlexBox
+        title={minifiedName === teamName ? null : teamName}
+        tooltipPlacement="right"
+        alignCenter
+        gap={1}
+          >
+        <Line big semibold sx={{ color: 'primary.dark' }}>
+          {minifiedName}
+        </Line>
+          </FlexBox>
+          <FlexBox gap={1}>
+        <EditTeam teamId={teamId} onEdit={onEdit} />
+        <MoreOptions teamId={team.id} />
+          </FlexBox>
+        </FlexBox>
+
+        <Divider />
+
+        <FlexBox col gap={2} flex={1}>
+          <FlexBox gap={1} alignCenter>
+        <Line bigish bold sx={{ color: 'text.primary' }}>
+          {assignedReposToTeam.length}{' '}
+          {pluralize('Repository', assignedReposToTeam.length)}
+        </Line>
           </FlexBox>
 
-          <FlexBox gap2 alignCenter minHeight={'64px'}>
-            <FlexBox gap1 alignCenter>
-              <Line bigish bold sx={{ whiteSpace: 'nowrap' }}>
-                {assignedReposToTeam.length}{' '}
-                {pluralize('Repo', assignedReposToTeam.length)} Added
-              </Line>
+          {Boolean(assignedReposToTeam.length) && (
+        <FlexBox col gap={1}>
+          {renderVisibleRepos}
+          
+          {assignedReposToTeam.length > VISIBLE_REPOS_COUNT && (
+            <FlexBox
+          inline
+          sx={{
+            userSelect: 'none',
+            ml: 1
+          }}
+          title={
+            <FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>
+          }
+            >
+          <Line info>
+            +{assignedReposToTeam.length - VISIBLE_REPOS_COUNT} more
+          </Line>
             </FlexBox>
-            {Boolean(assignedReposToTeam.length) && (
-              <>
-                <Divider orientation="vertical" flexItem />
-                <FlexBox justifyBetween alignCenter fullWidth>
-                  <Line secondary>
-                    {visibleReposName.map((r) => r.name).join(', ')}{' '}
-                    {assignedReposToTeam.length > VISIBLE_REPOS_COUNT && (
-                      <FlexBox
-                        inline
-                        sx={{
-                          userSelect: 'none'
-                        }}
-                        title={
-                          <FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>
-                        }
-                      >
-                        <Line info>
-                          +{assignedReposToTeam.length - VISIBLE_REPOS_COUNT}{' '}
-                          more
-                        </Line>
-                      </FlexBox>
-                    )}
-                  </Line>
-                </FlexBox>
-              </>
-            )}
-          </FlexBox>
+          )}
+        </FlexBox>
+          )}
+        </FlexBox>
+
+        <FlexBox justifyCenter mt={1}>
+          <Button
+        sx={{ width: '100%' }}
+        variant="contained"
+        onClick={() => onView(team)}
+        startIcon={<DoraIcon style={{ width: 20, height: 20 }} />}
+          >
+        View DORA Metrics
+          </Button>
         </FlexBox>
       </FlexBox>
-      <FlexBox col justifyBetween minHeight={'70px'} alignCenter>
-        <FlexBox
-          title={'View Dora Metrics'}
-          centered
-          width={'1.2em'}
-          maxWidth={'1.2em'}
-          pointer
-          onClick={() => onView(team)}
-        >
-          <DoraIcon />
         </FlexBox>
-        <EditTeam teamId={teamId} onEdit={onEdit} />
-        <FlexBox pointer>
-          <MoreOptions teamId={team.id} />
-        </FlexBox>
-      </FlexBox>
-    </FlexBox>
   );
+
 };
 
 const MoreOptions = ({ teamId }: { teamId: ID }) => {

--- a/web-server/src/components/TeamsList.tsx
+++ b/web-server/src/components/TeamsList.tsx
@@ -1,4 +1,3 @@
-
 import { Add, Delete, Edit, MoreVert } from '@mui/icons-material';
 import {
   Button,
@@ -297,7 +296,6 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
                   sx={{
                     userSelect: 'none',
                     mr: 20
-
                   }}
                   title={<FlexBox maxWidth={'250px'}>{tooltipRepos}</FlexBox>}
                 >
@@ -323,7 +321,6 @@ const TeamCard: React.FC<TeamCardProps> = ({ team, onEdit, onView }) => {
       </FlexBox>
     </FlexBox>
   );
-
 };
 
 const MoreOptions = ({ teamId }: { teamId: ID }) => {


### PR DESCRIPTION
resolves #639

This pull request enhances the `TeamsList` component in the `web-server` project by improving the UI and adding new features for better user experience. The most significant changes include the addition of `Avatar` and `AvatarGroup` components, UI styling updates, and the introduction of the `renderVisibleRepos` function.

UI Enhancements:

* [`web-server/src/components/TeamsList.tsx`](diffhunk://#diff-cab76ed84dfdb17a6b42c41138cf3ead6d1190d78ba9bfa00d5b71cb0d9f0853R1-R8): Added `Avatar` and `AvatarGroup` components to display repository avatars in the `TeamsList` component. [[1]](diffhunk://#diff-cab76ed84dfdb17a6b42c41138cf3ead6d1190d78ba9bfa00d5b71cb0d9f0853R1-R8) [[2]](diffhunk://#diff-cab76ed84dfdb17a6b42c41138cf3ead6d1190d78ba9bfa00d5b71cb0d9f0853R212-R241)
* [`web-server/src/components/TeamsList.tsx`](diffhunk://#diff-cab76ed84dfdb17a6b42c41138cf3ead6d1190d78ba9bfa00d5b71cb0d9f0853L223-R331): Updated `TeamCard` component styling, including changes to padding, minimum height, border radius, box shadow, and hover effects.

New Features:

* [`web-server/src/components/TeamsList.tsx`](diffhunk://#diff-cab76ed84dfdb17a6b42c41138cf3ead6d1190d78ba9bfa00d5b71cb0d9f0853R212-R241): Introduced the `renderVisibleRepos` function to render visible repositories with avatars and names in the `TeamCard` component.

![Shot-2025-03-26-040249](https://github.com/user-attachments/assets/411f1c5d-8d21-4f57-877b-99667a0e6e16)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the team profile view with a consolidated display of repository avatars and names.
  - Integrated tooltips for additional repository details.

- **Style**
  - Refined layout with improved spacing, padding, and a dynamic hover effect for a more engaging user experience.
  - Updated text color for better visibility and alignment within the TeamCard component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->