### PR TITLE
Fix the invalid token bug for default github instances

### DIFF
--- a/backend/analytics_server/mhq/utils/github.py
+++ b/backend/analytics_server/mhq/utils/github.py
@@ -54,7 +54,6 @@ def github_org_data_multi_thread_worker(orgs: [Organization]) -> dict:
 
 
 def get_custom_github_domain(org_id: str) -> Optional[str]:
-    DEFAULT_DOMAIN = "https://api.github.com"
     core_repo_service = CoreRepoService()
     integrations = core_repo_service.get_org_integrations_for_names(
         org_id, [UserIdentityProvider.GITHUB.value]
@@ -70,6 +69,8 @@ def get_custom_github_domain(org_id: str) -> Optional[str]:
         LOG.warn(
             f"Custom domain not found for intergration for org {org_id} and provider {UserIdentityProvider.GITHUB.value}"
         )
-        return DEFAULT_DOMAIN
+        # return nothing when custom domain is not found
+        # this is to prevent the default domain from being used
+        return
 
     return github_domain


### PR DESCRIPTION
## Linked Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
Regression caused by #646 
Fixes #653 

## Proposed changes (including videos or screenshots)

Actually the problem the `get_custom_github_domain` was returning a default github domain when no custom domain existed. Then we were doing a domain check again in the `GithubApiService`. This resulted in the final api looking like `api.github.com/api/v3`.

Now the get_custom_github_domain implicitly return a None allowing for a comparision to happen in GithubApiService

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated handling of missing custom GitHub domains to return no value instead of a default domain.
  - Added clarification in comments regarding the intentional absence of a default domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->