### PR TITLE
Update docker images and build images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG MERGE_COMMIT_SHA
 
 
 # Build the backend
-FROM python:3.9-slim as backend-build
+FROM python:3.9-slim-bookworm as backend-build
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && /opt/venv/bin/pip install -r requirements.txt
 
 # Final image
-FROM python:3.9-slim
+FROM python:3.9-slim-bookworm
 
 ARG BUILD_DATE
 ARG MERGE_COMMIT_SHA

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,4 +1,4 @@
-FROM python:3.9-slim as oss-base
+FROM python:3.9-slim-bookworm as oss-base
 
 # Install necessary packages for building the backend
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/database-docker/Dockerfile
+++ b/database-docker/Dockerfile
@@ -1,19 +1,22 @@
-FROM debian:buster
+FROM debian:bookworm
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get -y install gnupg
 RUN apt-get -y install curl
 RUN apt-get -y install wget
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update
-RUN apt-get -y install postgresql-14
-RUN curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-amd64
-RUN chmod +x /usr/local/bin/dbmate
+RUN apt-get -y install postgresql-15
+
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-${ARCH} && \
+    chmod +x /usr/local/bin/dbmate
+
 WORKDIR /
 RUN mkdir ./db
 COPY ./db/ ./db/
-ENV PATH /usr/lib/postgresql/14/bin:$PATH
+ENV PATH /usr/lib/postgresql/15/bin:$PATH
 ADD ./dbwait.sh /bin
 RUN chmod +x /bin/dbwait.sh


### PR DESCRIPTION
## Linked Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
Related to https://github.com/middlewarehq/middleware/issues/619#issuecomment-2555784290

The above comment mentioned about buster being depricated, so this PR attempts to update it

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

1. Updated The buster images to bookworm
2. Updated postgres from 14 to 15(No breaking changes observed)
3. Updated command to install dbmate based on system architecture instead of using amd64 in general


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated backend and database Docker images to use newer Debian Bookworm base images.
  - Upgraded PostgreSQL version from 14 to 15 in the database container.
  - Enhanced database migration tool compatibility by dynamically selecting the appropriate binary for the system architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->