### PR TITLE
FIX : docs: add missing PORT variable to env example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ To set up middleware locally, follow these steps:
       REDIS_PORT=6385
       ANALYTICS_SERVER_PORT=9696
       SYNC_SERVER_PORT=9697
+      PORT=3333
       DEFAULT_SYNC_DAYS=31
       ```
 


### PR DESCRIPTION
This PR makes a minor update to the README to include the missing `PORT` environment variable required for running the frontend locally using `yarn dev`.

I used the steps in the README to setup middleware locally and faced the following error.
<img width="1161" height="302" alt="ref" src="https://github.com/user-attachments/assets/6ecb22f8-537d-4f50-821c-20830d5b37ee" />

.env.example file has it right. Its just missing in the README.

Let me know you if you have any suggestions.

Thanks,
Ritik 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated manual setup instructions to include the `PORT=3333` environment variable in the example configuration for running middleware locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->