### PR TITLE
Exclude COMMITTED events from adapted timeline

### DIFF
--- a/backend/analytics_server/mhq/exapi/github.py
+++ b/backend/analytics_server/mhq/exapi/github.py
@@ -18,6 +18,7 @@ from mhq.exapi.schemas.timeline import (
 )
 from mhq.exapi.models.github import GitHubContributor
 from mhq.exapi.models.github_timeline import GithubPullRequestTimelineEvents
+from mhq.store.models.code.enums import PullRequestEventType
 from mhq.utils.log import LOG
 
 PAGE_SIZE = 100
@@ -373,11 +374,10 @@ class GithubApiService:
 
             event = GithubPullRequestTimelineEvents(event_type, event_data)
 
-            if all([event.timestamp, event.type, event.id, event.user]):
+            if (
+                all([event.timestamp, event.type, event.id, event.user])
+                and event.type != PullRequestEventType.COMMITTED
+            ):
                 adapted_timeline_events.append(event)
-            else:
-                LOG.warning(
-                    f"Skipping incomplete timeline event: {event_type} with id: {event.id}"
-                )
 
         return adapted_timeline_events


### PR DESCRIPTION
## Linked Issue(s)

Closes #678

## Further comments

Hash can be same for commits in different PRs.  
Later we would also need to handle this case for `PullRequestCommit` table, as we use currently use hash as Primary Key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of timeline events to exclude specific event types and prevent incomplete events from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->