### PR TITLE
Fix Invalid time range issue

### DIFF
--- a/web-server/src/layouts/ExtendedSidebarLayout/Sidebar/index.tsx
+++ b/web-server/src/layouts/ExtendedSidebarLayout/Sidebar/index.tsx
@@ -7,7 +7,7 @@ import {
   useTheme,
   lighten
 } from '@mui/material';
-import { format } from 'date-fns';
+import { format, isValid } from 'date-fns';
 import { useContext, useMemo } from 'react';
 
 import { FlexBox } from '@/components/FlexBox';
@@ -67,11 +67,9 @@ const SidebarContent = () => {
 
   const imageStatus = useSelector((s) => s.app.latestImageStatus);
 
-  const formattedDate = imageStatus?.current_docker_image_build_date
-    ? format(
-        new Date(imageStatus.current_docker_image_build_date),
-        'dd MMM yyyy HH:mm:ss'
-      )
+  const imageBuildDate = new Date(imageStatus?.current_docker_image_build_date);
+  const formattedDate = isValid(imageBuildDate)
+    ? format(imageBuildDate, 'dd MMM yyyy HH:mm:ss')
     : 'Not Available';
 
   return (

--- a/web-server/src/layouts/ExtendedSidebarLayout/Sidebar/index.tsx
+++ b/web-server/src/layouts/ExtendedSidebarLayout/Sidebar/index.tsx
@@ -67,10 +67,12 @@ const SidebarContent = () => {
 
   const imageStatus = useSelector((s) => s.app.latestImageStatus);
 
-  const formattedDate = format(
-    new Date(imageStatus.current_docker_image_build_date),
-    'dd MMM yyyy HH:mm:ss'
-  );
+  const formattedDate = imageStatus?.current_docker_image_build_date
+    ? format(
+        new Date(imageStatus.current_docker_image_build_date),
+        'dd MMM yyyy HH:mm:ss'
+      )
+    : 'Not Available';
 
   return (
     <>


### PR DESCRIPTION
## Linked Issue(s)

Fixes #685 

## Acceptance Criteria fulfilment

- [x] Handle failed api gracefully
- [x] Get full tag details with images via docker hub api

## Comments

I have updated the method to get architecture info for that specific tag only. This api is more likely to send stable response even in future updates.

Also for any docker api changes as mentioned [here](https://github.com/docker/hub-feedback/issues/2484#issuecomment-3185841599), it won't affect our system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar no longer errors when the build date is missing; shows “Build: Not Available.”
  * Image release detection now prefers the appropriate amd64 digest and tolerates missing digests.
  * Image link handling falls back to a general tags view when no digest is available.

* **Performance**
  * Release checks now fetch only the latest tag, reducing network requests and latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->