### PR TITLE
Add healthcheck routes

### DIFF
--- a/web-server/app/ping/route.ts
+++ b/web-server/app/ping/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// For plain text response
+export function GET(request: NextRequest) {
+  return new Response('OK', {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}

--- a/web-server/app/ping/route.ts
+++ b/web-server/app/ping/route.ts
@@ -1,9 +1,7 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { NextResponse } from "next/server";
 
-// For plain text response
-export function GET(request: NextRequest) {
-  return new Response('OK', {
+export function GET() {
+  return new NextResponse('OK', {
     status: 200,
     headers: { 'Content-Type': 'text/plain' },
   });

--- a/web-server/app/ping/route.ts
+++ b/web-server/app/ping/route.ts
@@ -3,6 +3,10 @@ import { NextResponse } from "next/server";
 export function GET() {
   return new NextResponse('OK', {
     status: 200,
-    headers: { 'Content-Type': 'text/plain' },
+    headers: {
+      'Content-Type': 'text/plain',
+      'Cache-Control': 'no-store',
+      'X-Robots-Tag': 'noindex'
+    },
   });
 }

--- a/web-server/app/status/route.ts
+++ b/web-server/app/status/route.ts
@@ -8,12 +8,19 @@ try {
   const pkgJson = JSON.parse(readFileSync(pkgPath, 'utf8'));
   version = pkgJson.version || 'unknown';
 } catch (err) {
-  console.log(err);
+  console.warn('status route: failed to read package.json for version', err instanceof Error ? err.message : err);
 }
 
 export async function GET() {
   return NextResponse.json({
     status: 'OK',
     version,
+  },
+  {
+    headers: {
+      'Content-Type': 'text/plain',
+      'Cache-Control': 'no-store',
+      'X-Robots-Tag': 'noindex',
+    },
   });
 }

--- a/web-server/app/status/route.ts
+++ b/web-server/app/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { readFileSync } from 'node:fs';
-import { join } from 'path';
+import { join } from 'node:path';
 
 let version = 'unknown';
 try {

--- a/web-server/app/status/route.ts
+++ b/web-server/app/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'path';
 
 let version = 'unknown';
@@ -18,7 +18,6 @@ export async function GET() {
   },
   {
     headers: {
-      'Content-Type': 'text/plain',
       'Cache-Control': 'no-store',
       'X-Robots-Tag': 'noindex',
     },

--- a/web-server/app/status/route.ts
+++ b/web-server/app/status/route.ts
@@ -1,20 +1,17 @@
 import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-// Read and cache the version at module load
 let version = 'unknown';
 try {
   const pkgPath = join(process.cwd(), 'package.json');
   const pkgJson = JSON.parse(readFileSync(pkgPath, 'utf8'));
   version = pkgJson.version || 'unknown';
 } catch (err) {
-    console.log(err);
-  // If reading fails, version stays 'unknown'
+  console.log(err);
 }
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   return NextResponse.json({
     status: 'OK',
     version,

--- a/web-server/app/status/route.ts
+++ b/web-server/app/status/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Read and cache the version at module load
+let version = 'unknown';
+try {
+  const pkgPath = join(process.cwd(), 'package.json');
+  const pkgJson = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  version = pkgJson.version || 'unknown';
+} catch (err) {
+    console.log(err);
+  // If reading fails, version stays 'unknown'
+}
+
+export async function GET(request: NextRequest) {
+  return NextResponse.json({
+    status: 'OK',
+    version,
+  });
+}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
Add healthcheck routes that can be used with Kubernetes readiness processes.
Two routes have been added:
- `/ping` that return a plain text status 200
- `/status` that returns a json output status 200
<!-- END CHANGELOG -->

## Further comments

This should be beneficial for anyone who wants to deployed the app in a Kubernetes setup. More info there:
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

Test with the following (change the URL to whatever it should be):

```sh
curl -IL https://3333-itv-middleware-5talawwxbrr.ws-eu121.gitpod.io/ping
curl -IL https://3333-itv-middleware-5talawwxbrr.ws-eu121.gitpod.io/status
```

<img width="668" height="243" alt="Screenshot 2025-09-15 at 10 48 46" src="https://github.com/user-attachments/assets/8e663241-6f89-440b-b474-a30a4b7d67e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a lightweight /ping health-check endpoint that returns plain-text “OK”; responses are non-cacheable and excluded from indexing.
  - Added a /status endpoint that returns service status and the application version in JSON; version may be reported as "unknown" if unavailable. Both endpoints support monitoring and load‑balancer probes without affecting caching or search indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->