### PR TITLE
feat: Backend API for PRs Merged Without Review

### DIFF
--- a/backend/analytics_server/mhq/api/pull_requests.py
+++ b/backend/analytics_server/mhq/api/pull_requests.py
@@ -167,3 +167,38 @@ def get_team_lead_time_trends(
         week.isoformat(): adapt_lead_time_metrics(average_lead_time_metrics)
         for week, average_lead_time_metrics in weekly_lead_time_metrics_avg_map.items()
     }
+
+@app.route("/teams/<team_id>/prs/merged_without_review", methods={"GET"})
+@queryschema(
+    Schema({
+        Required("from_time"): All(str, Coerce(datetime.fromisoformat)),
+        Required("to_time"):   All(str, Coerce(datetime.fromisoformat)),
+        Optional("pr_filter"): All(str, Coerce(json.loads)),
+    })
+)
+def get_prs_merged_without_review(
+    team_id: str,
+    from_time: datetime,
+    to_time: datetime,
+    pr_filter: Dict = None,
+) -> List[PullRequest]:
+    query_validator = get_query_validator()
+    
+    pr_analytics = get_pr_analytics_service() 
+
+    interval: Interval = query_validator.interval_validator(from_time, to_time)
+    
+    pr_filter: PRFilter = apply_pr_filter(
+        pr_filter, EntityType.TEAM, team_id, [SettingType.EXCLUDED_PRS_SETTING]
+    )
+
+    team_repos = pr_analytics.get_team_repos(team_id)
+    if not team_repos:
+        return [] 
+
+    repo_ids = [repo.id for repo in team_repos]
+
+    prs = pr_analytics.get_prs_merged_without_review(repo_ids, interval, pr_filter)
+
+    repo_id_repo_map = {repo.id: repo for repo in team_repos}
+    return get_non_paginated_pr_response(prs, repo_id_repo_map, len(prs))

--- a/backend/analytics_server/mhq/service/code/pr_analytics.py
+++ b/backend/analytics_server/mhq/service/code/pr_analytics.py
@@ -1,6 +1,8 @@
+from mhq.store.models.code.filter import PRFilter
+from mhq.store.models.core.teams import Team
+from mhq.utils.time import Interval
 from mhq.store.models.code import OrgRepo, PullRequest
 from mhq.store.repos.code import CodeRepoService
-
 from typing import List, Optional
 
 
@@ -17,6 +19,8 @@ class PullRequestAnalyticsService:
     def get_repo_by_id(self, repo_id: str) -> Optional[OrgRepo]:
         return self.code_repo_service.get_repo_by_id(repo_id)
 
+    def get_prs_merged_without_review(self, repo_ids: List[str], interval: Interval, pr_filter: PRFilter) -> List[PullRequest]:
+        return self.code_repo_service.get_prs_merged_without_review(repo_ids, interval, pr_filter)
 
 def get_pr_analytics_service():
     return PullRequestAnalyticsService(CodeRepoService())

--- a/backend/analytics_server/mhq/store/repos/code.py
+++ b/backend/analytics_server/mhq/store/repos/code.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from operator import and_
 from typing import Optional, List
 
-from mhq.store.models.code.enums import CodeProvider
-from sqlalchemy import or_
+from mhq.store.models.code.enums import CodeProvider, PullRequestEventType
+from sqlalchemy import or_, not_, exists
 from sqlalchemy.orm import defer
 from mhq.store.models.core import Team
 
@@ -282,6 +282,35 @@ class CodeRepoService:
             .filter(OrgRepo.id.in_(repo_ids), OrgRepo.is_active.is_(True))
             .all()
         )
+
+    @rollback_on_exc
+    def get_prs_merged_without_review(
+        self, 
+        repo_ids: List[str],
+        interval: Interval,
+        pr_filter: PRFilter = None,
+    ) -> List[PullRequest]:
+        query = self._db.session.query(PullRequest).options(defer(PullRequest.data))
+
+        query = self._filter_prs_by_repo_ids(query, repo_ids)
+        query = self._filter_prs_merged_in_interval(query, interval)
+
+        query = self._filter_prs(query, pr_filter)
+        
+        query = query.filter(
+            not_(
+                exists().where(
+                    and_(
+                        PullRequestEvent.pull_request_id == PullRequest.id,
+                        PullRequestEvent.type == PullRequestEventType.REVIEW,
+                    )
+                )
+            )   
+        )
+
+        query = query.order_by(PullRequest.state_changed_at.asc())
+
+        return query.all()
 
     @rollback_on_exc
     def get_prs_merged_in_interval(


### PR DESCRIPTION
## Linked Issue(s)

Closes #207  

## Acceptance Criteria Fulfillment

- [x] Added a Python backend API to fetch a team’s pull requests merged without any review.

## Proposed Changes

- Introduced a new API endpoint:  
  **`/teams/<team_id>/prs/merged_without_review`** — retrieves all pull requests merged without any review activity.  
- Implemented the backend query logic to accurately identify PRs with no associated review events within the specified time interval.

### API Response Example
Below is an example response from the new API:  
<img width="992" height="890" alt="API Response" src="https://github.com/user-attachments/assets/be9489b6-0df8-4d14-9f1b-2a95faa96d26" />

### UI Reference (For Context Only)
The following screenshots illustrate how this data could be visualized in the UI.  
Note: This PR only includes backend API changes  the UI is shown for reference.  

<img width="1919" height="956" alt="All PRs View" src="https://github.com/user-attachments/assets/67abd3f7-6550-4b62-a17e-efeea3ebad71" />  

<img width="1919" height="948" alt="Merged Without Review View" src="https://github.com/user-attachments/assets/19125e3d-a7fc-44ca-9f75-f7f487f4c516" />  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new analytics capability to retrieve and analyze merged pull requests that were not reviewed. Supports filtering by team, time intervals, and optional criteria to provide insights into unreviewed merged code and code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->