### PR TITLE
fix: resolve missing lead time breakdown when review events are absen…

### DIFF
--- a/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
@@ -24,7 +24,7 @@ class CodeETLAnalyticsService:
         if pr.state == PullRequestState.OPEN:
             return pr
         non_bot_pr_events = self.filter_non_bot_events(pr_events)
-        pr_performance = self.get_pr_performance(pr, non_bot_pr_events) 
+        pr_performance = self.get_pr_performance(pr, non_bot_pr_events)
         pr.first_response_time = (
             pr_performance.first_review_time
             if pr_performance.first_review_time != -1
@@ -90,9 +90,7 @@ class CodeETLAnalyticsService:
         )
 
         first_response_end_time = (
-            first_review.created_at
-            if first_review
-            else pr.state_changed_at
+            first_review.created_at if first_review else pr.state_changed_at
         )
 
         if not approved_reviews:
@@ -110,7 +108,7 @@ class CodeETLAnalyticsService:
         if pr.state != PullRequestState.MERGED:
             merge_time = -1
         elif not approved_reviews:
-            merge_time = 0  
+            merge_time = 0
         else:
             merge_time = (
                 pr.state_changed_at - approved_reviews[0].created_at

--- a/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
@@ -23,10 +23,8 @@ class CodeETLAnalyticsService:
     ) -> PullRequest:
         if pr.state == PullRequestState.OPEN:
             return pr
-
         non_bot_pr_events = self.filter_non_bot_events(pr_events)
-        pr_performance = self.get_pr_performance(pr, non_bot_pr_events)
-
+        pr_performance = self.get_pr_performance(pr, non_bot_pr_events) 
         pr.first_response_time = (
             pr_performance.first_review_time
             if pr_performance.first_review_time != -1
@@ -60,7 +58,6 @@ class CodeETLAnalyticsService:
 
     @staticmethod
     def get_pr_performance(pr: PullRequest, pr_events: [PullRequestEvent]):
-
         review_events = [
             event
             for event in pr_events
@@ -92,8 +89,16 @@ class CodeETLAnalyticsService:
             )
         )
 
+        first_response_end_time = (
+            first_review.created_at
+            if first_review
+            else pr.state_changed_at
+        )
+
         if not approved_reviews:
-            rework_time = -1
+            rework_time = (
+                pr.state_changed_at - first_response_end_time
+            ).total_seconds()
         else:
             if first_review.data.get("state") == PullRequestEventState.APPROVED.value:
                 rework_time = 0
@@ -102,8 +107,10 @@ class CodeETLAnalyticsService:
                     approved_reviews[0].created_at - first_review.created_at
                 ).total_seconds()
 
-        if pr.state != PullRequestState.MERGED or not approved_reviews:
+        if pr.state != PullRequestState.MERGED:
             merge_time = -1
+        elif not approved_reviews:
+            merge_time = 0  
         else:
             merge_time = (
                 pr.state_changed_at - approved_reviews[0].created_at
@@ -124,9 +131,9 @@ class CodeETLAnalyticsService:
         return PRPerformance(
             first_review_time=(
                 (
-                    first_review.created_at - pull_request_ready_for_review_time
+                    first_response_end_time - pull_request_ready_for_review_time
                 ).total_seconds()
-                if first_review
+                if first_response_end_time
                 else -1
             ),
             rework_time=rework_time,

--- a/backend/analytics_server/tests/service/code/sync/test_etl_code_analytics.py
+++ b/backend/analytics_server/tests/service/code/sync/test_etl_code_analytics.py
@@ -21,11 +21,15 @@ def test_pr_performance_returns_first_review_tat_for_first_review():
     assert performance.first_review_time == 3600
 
 
-def test_pr_performance_returns_minus1_first_review_tat_for_no_reviews():
+def test_pr_performance_returns_first_review_time_as_fallback_for_no_reviews():
     pr_service = CodeETLAnalyticsService()
-    pr = get_pull_request()
+    t1 = time_now()
+    t2 = t1 + timedelta(minutes=30)
+    pr = get_pull_request(
+        state=PullRequestState.MERGED, state_changed_at=t2, created_at=t1, updated_at=t2
+    )
     performance = pr_service.get_pr_performance(pr, [])
-    assert performance.first_review_time == -1
+    assert performance.first_review_time == 1800.0
 
 
 def test_pr_performance_returns_minus1_first_approved_review_tat_for_no_approved_review():
@@ -40,7 +44,7 @@ def test_pr_performance_returns_minus1_first_approved_review_tat_for_no_approved
     assert performance.merge_time == -1
 
 
-def test_pr_performance_returns_merge_time_minus1_for_merged_pr_without_review():
+def test_pr_performance_returns_merge_time_zero_for_merged_pr_without_review():
     pr_service = CodeETLAnalyticsService()
     t1 = time_now()
     t2 = time_now() + timedelta(minutes=30)
@@ -48,7 +52,7 @@ def test_pr_performance_returns_merge_time_minus1_for_merged_pr_without_review()
         state=PullRequestState.MERGED, state_changed_at=t2, created_at=t1, updated_at=t2
     )
     performance = pr_service.get_pr_performance(pr, [])
-    assert performance.merge_time == -1
+    assert performance.merge_time == 0
 
 
 def test_pr_performance_returns_blocking_reviews():
@@ -156,11 +160,14 @@ def test_pr_performance_returns_rework_time_for_open_prs():
     assert performance.rework_time == (t3 - t2).total_seconds()
 
 
-def test_pr_performance_returns_rework_time_minus1_for_non_approved_prs():
+def test_pr_performance_returns_rework_time_for_non_approved_prs():
     pr_service = CodeETLAnalyticsService()
     t1 = time_now()
     t2 = t1 + timedelta(hours=1)
-    pr = get_pull_request(state=PullRequestState.OPEN, created_at=t1, updated_at=t1)
+    t3 = t2 + timedelta(hours=2)
+    pr = get_pull_request(
+        state=PullRequestState.OPEN, created_at=t1, updated_at=t1, state_changed_at=t3
+    )
     changes_requested_1 = get_pull_request_event(
         pull_request_id=pr.id,
         state=PullRequestEventState.CHANGES_REQUESTED.value,
@@ -168,10 +175,10 @@ def test_pr_performance_returns_rework_time_minus1_for_non_approved_prs():
     )
     performance = pr_service.get_pr_performance(pr, [changes_requested_1])
 
-    assert performance.rework_time == -1
+    assert performance.rework_time == (t3 - t2).total_seconds()
 
 
-def test_pr_performance_returns_rework_time_minus1_for_merged_prs_without_reviews():
+def test_pr_performance_returns_rework_time_zero_for_merged_prs_without_reviews():
     pr_service = CodeETLAnalyticsService()
     t1 = time_now()
     pr = get_pull_request(
@@ -179,7 +186,7 @@ def test_pr_performance_returns_rework_time_minus1_for_merged_prs_without_review
     )
     performance = pr_service.get_pr_performance(pr, [])
 
-    assert performance.rework_time == -1
+    assert performance.rework_time == 0.0
 
 
 def test_pr_performance_returns_cycle_time_for_merged_pr():


### PR DESCRIPTION
# Summary
Fixes #696
Fixes incorrect Lead Time breakdown calculations when PRs are merged without review and/or approval events.

Previously, if a PR skipped parts of the review chain, portions of the elapsed lifecycle time were not attributed to any breakdown component, causing the breakdown totals to not reconcile with the overall lead/cycle time.

---

# Problem

The existing implementation assumes the following review chain always exists:

```text
Ready for Review → Review → Approval → Merge
```

However, some PRs may be:
- merged without reviews
- reviewed but merged without approval

In those cases:
- `first_review_time`
- `rework_time`
- `merge_time`

were set to `-1` / `None`, causing parts of the elapsed time to disappear from the Lead Time breakdown.

Example:

| Scenario | Missing Time |
|---|---|
| No review + no approval | ready → merge |
| Review exists, no approval | review → merge |

As a result, the total cycle time remained correct, but the breakdown components no longer summed to the total.

---

# Solution

Implemented fallback timing behavior so elapsed time is attributed to the next logical stage when review events are missing.

Fallback behavior:

| Scenario | Response Time | Rework Time | Merge Time |
|---|---|---|---|
| Review + Approval | ready → review | review → approval | approval → merge |
| Review, no Approval | ready → review | review → merge | 0 |
| No Review, no Approval | ready → merge | 0 | 0 |

This ensures:
- no elapsed lifecycle time is lost
- breakdown components reconcile with total lead/cycle time
- analytics remain meaningful even for unreviewed PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request metrics by excluding bot-created events from analytics calculations.
  * Reworked rework and merge time logic to return meaningful durations (including zero for merged PRs without reviews) instead of placeholder values when review data is missing.
  * Fixed first-review time to use a reliable fallback timestamp so it reports an actual duration when review timestamps are absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/middlewarehq/middleware/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->