### PR TITLE
fix(analytics): include draft PR duration in commit to open segment

### DIFF
--- a/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
+++ b/backend/analytics_server/mhq/service/code/sync/etl_code_analytics.py
@@ -50,7 +50,10 @@ class CodeETLAnalyticsService:
         if pr_commits:
             pr.rework_cycles = self.get_rework_cycles(pr, non_bot_pr_events, pr_commits)
             pr_commits.sort(key=lambda x: x.created_at)
-            first_commit_to_open = pr.created_at - pr_commits[0].created_at
+            first_commit_to_open = (
+                pr_performance.pull_request_ready_for_review_time
+                - pr_commits[0].created_at
+            )
             if isinstance(first_commit_to_open, timedelta):
                 pr.first_commit_to_open = first_commit_to_open.total_seconds()
 
@@ -134,6 +137,7 @@ class CodeETLAnalyticsService:
                 if first_response_end_time
                 else -1
             ),
+            pull_request_ready_for_review_time=pull_request_ready_for_review_time,
             rework_time=rework_time,
             merge_time=merge_time,
             cycle_time=cycle_time if pr.state == PullRequestState.MERGED else -1,

--- a/backend/analytics_server/mhq/service/code/sync/models.py
+++ b/backend/analytics_server/mhq/service/code/sync/models.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class PRPerformance:
     first_commit_to_open: int = -1
     first_review_time: int = -1
+    pull_request_ready_for_review_time: int = -1
     rework_time: int = -1
     merge_time: int = -1
     merge_to_deploy: int = -1

--- a/backend/analytics_server/tests/service/code/sync/test_etl_code_analytics.py
+++ b/backend/analytics_server/tests/service/code/sync/test_etl_code_analytics.py
@@ -751,3 +751,28 @@ def test_cycle_time_ready_for_review_with_draft_pr_workflow():
 
     assert performance.cycle_time == 86400
     assert performance.first_review_time == 14400
+
+
+def test_create_pr_metrics_calculates_first_commit_to_open_using_ready_for_review():
+    """Test that first_commit_to_open correctly accounts for the draft PR window."""
+    pr_service = CodeETLAnalyticsService()
+    t1 = time_now()  # commit time
+    t2 = t1 + timedelta(hours=20)  # pr created
+    t3 = t2 + timedelta(
+        hours=2
+    )  # sat in draft for 2 hours (ready_for_review event time)
+
+    pr = get_pull_request(state=PullRequestState.MERGED, created_at=t2, updated_at=t3)
+    commit = get_pull_request_commit(pr_id=pr.id, created_at=t1)
+
+    ready_for_review_event = get_pull_request_event(
+        pull_request_id=pr.id,
+        type=PullRequestEventType.READY_FOR_REVIEW.value,
+        created_at=t3,
+    )
+
+    updated_pr = pr_service.create_pr_metrics(pr, [ready_for_review_event], [commit])
+
+    expected_seconds = (t3 - t1).total_seconds()
+
+    assert updated_pr.first_commit_to_open == expected_seconds


### PR DESCRIPTION
## Summary

This fixes the lead time calculation for pull requests opened as drafts.

Previously, the first_commit_to_open metric used pr.created_at, which caused the time spent in draft mode to be omitted from the Lead Time breakdown.

This change updates the calculation to use the ready_for_review timestamp instead. For PRs opened directly as non-drafts, behavior remains unchanged because the PR creation and ready-for-review timestamps are effectively identical.

Fixes #698.

**Before**
<img width="650" height="116" alt="image" src="https://github.com/user-attachments/assets/11d819bd-bd9c-4a12-a0d1-35070d0cef8d" />


## Changes
Update first_commit_to_open to use pull_request_ready_for_review_time
Preserve existing behavior for non-draft PRs
Add a test covering draft PRs

**After** 
<img width="467" height="83" alt="image" src="https://github.com/user-attachments/assets/a57bc400-7066-4b90-9adf-aa5c0c285e7b" />

## Testing

Added a unit test verifying that:

a PR opened as a draft
remaining in draft for several hours
then marked ready for review

correctly includes the draft duration in the first_commit_to_open metric

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how pull request timing metrics are calculated so “first commit to open” now reflects the ready-for-review point instead of the initial creation time.
  * Added support for tracking a pull request’s ready-for-review timestamp in performance metrics, making reported timing data more accurate.
* **Tests**
  * Added coverage for the updated pull request metric calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->