### PR TITLE
Fix GitLab repo-fetch parent derivation and its test mock

### DIFF
--- a/web-server/pages/api/internal/[org_id]/__tests__/git_org_repos.test.ts
+++ b/web-server/pages/api/internal/[org_id]/__tests__/git_org_repos.test.ts
@@ -80,8 +80,8 @@ jest.mock('@/api/internal/[org_id]/utils', () => ({
               pageInfo: { hasNextPage: false, endCursor: null },
               nodes: [
                 {
-                  id: 'p1',
-                  fullPath: 'g/p1',
+                  id: 'gid://gitlab/Project/101',
+                  fullPath: 'gspace/p1',
                   name: 'proj1',
                   webUrl: 'w1',
                   description: 'd1',
@@ -115,7 +115,7 @@ jest.mock('@/api/internal/[org_id]/utils', () => ({
       expect(result.totalCount).toBeNull()
       expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: null })
       expect(result.repos).toHaveLength(1)
-      expect(result.repos[0]).toMatchObject({ id: 'p1', name: 'proj1', slug: 'p1', web_url: 'w1', branch: 'dev', parent: 'gspace' })
+      expect(result.repos[0]).toMatchObject({ id: 101, name: 'proj1', slug: 'p1', web_url: 'w1', branch: 'dev', parent: 'gspace' })
     })
   })
 

--- a/web-server/pages/api/internal/[org_id]/git_org_repos.ts
+++ b/web-server/pages/api/internal/[org_id]/git_org_repos.ts
@@ -187,7 +187,7 @@ export async function fetchRepos(params: {
         slug: repo.path,
         web_url: repo.webUrl,
         branch: repo.repository?.rootRef || null,
-        parent: repo.fullPath.split('/').slice(0, -1).join('/'),
+        parent: repo.namespace.fullPath,
         provider: Integration.GITLAB,
       }) as BaseRepo
   )


### PR DESCRIPTION
## Summary

Fixes #702.

`fetchRepos`'s GitLab branch (`web-server/pages/api/internal/[org_id]/git_org_repos.ts`)
re-derived `parent` from `repo.fullPath` via string splitting, even though the GraphQL
query already fetches `namespace.fullPath` — the field that directly represents it. The
derivation is mathematically equivalent for well-formed data, so it wasn't a production
bug, but it was redundant, and it was the root cause of a stale test fixture: the mock's
`fullPath` and `namespace.fullPath` were mutually inconsistent with each other, and its
`id` wasn't shaped like a real GitLab GID (`gid://gitlab/Project/...`). Both caused the
GitLab case of `fetchRepos`'s test to fail ever since it was introduced in #672.

## Changes

- `git_org_repos.ts`: read `parent` from `repo.namespace.fullPath` directly instead of
  re-deriving it from `repo.fullPath`.
- `git_org_repos.test.ts`: use a realistic, internally-consistent GitLab GraphQL mock
  (GID-shaped `id`, `fullPath`/`namespace.fullPath` that agree with each other), and
  correct the assertion's expected `id` to a number, matching what the implementation
  actually returns.

## Test plan

- `cd web-server && npx jest --watchAll=false --passWithNoTests -t "fetchRepos"` — both
  GitHub and GitLab cases now pass (previously the GitLab case failed).
- `npx tsc --noEmit` — clean.
- `npx eslint "pages/api/internal/[org_id]/git_org_repos.ts"` — no new findings (verified
  identical pre-existing warning/error count on `main` before this change; this file has
  pre-existing lint debt unrelated to this fix, left untouched per scope).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitLab repository organization mapping for more accurate parent relationships.
  * Updated repository identification to use numeric project IDs consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->